### PR TITLE
ci: Add CI job to publish docker image description to hub.docker.com

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,6 +115,23 @@ publish-docker-bot:
   variables:
     DOCKERFILE:                    "Dockerfile"
 
+publish-docker-image-description:
+  stage:                           build
+  <<:                              *kubernetes-env
+  variables:
+    CI_IMAGE:                      paritytech/dockerhub-description
+    DOCKERHUB_REPOSITORY:          paritytech/substrate-tip-bot
+    DOCKER_USERNAME:               $Docker_Hub_User_Parity
+    DOCKER_PASSWORD:               $Docker_Hub_Pass_Parity
+    README_FILEPATH:               $CI_PROJECT_DIR/Dockerfile.README.md
+    SHORT_DESCRIPTION:             "A GitHub App built with Probot that can submit tips on behalf of a Substrate based network"
+  rules:
+    - if: $CI_COMMIT_REF_NAME == "master"
+      changes:
+      - Dockerfile.README.md
+  script:
+    - cd / && sh entrypoint.sh
+
 #### stage:                        deploy
 
 .deploy:                           &deploy-k8s

--- a/Dockerfile.README.md
+++ b/Dockerfile.README.md
@@ -1,0 +1,15 @@
+# substrate-tip-bot
+
+## A GitHub App built with Probot that can submit tips on behalf of a Substrate based network.
+
+To run the bot via Docker:
+
+```
+$ docker run \
+    -e APP_ID=<app-id> \
+    -e PRIVATE_KEY=<pem-value> \
+    paritytech/substrate-tip-bot
+```
+
+
+### More on a [GitHub](https://github.com/paritytech/substrate-tip-bot)


### PR DESCRIPTION
Added CI job to publish Docker image description to [hub.docker.com](https://hub.docker.com/r/paritytech/substrate-tip-bot)
Description can be updated in a `Dockerfile.README.md` file in a repository root and as soon it will be merged into the `master` branch, its content will get published to [hub.docker.com](https://hub.docker.com/r/paritytech/substrate-tip-bot)

Related https://github.com/paritytech/ci_cd/issues/741