### PR TITLE
Add tip bot balance to metrics

### DIFF
--- a/src/balance.ts
+++ b/src/balance.ts
@@ -1,19 +1,19 @@
 import { ApiPromise, WsProvider } from "@polkadot/api";
 import { BN } from "@polkadot/util";
+import type { Probot } from "probot";
 
 import { getChainConfig } from "./chain-config";
 import { balanceGauge } from "./metrics";
 import { TipNetwork } from "./types";
-import type { Probot } from "probot";
 
 export const updateAllBalances = async (tipBotAddress: string, log: Probot["log"]): Promise<void> => {
   const networks: TipNetwork[] = ["localpolkadot", "localkusama", "kusama", "polkadot"];
   for (const network of networks) {
-    log.info(`Checking tip bot balance on ${network}`)
+    log.info(`Checking tip bot balance on ${network}`);
     try {
       await updateBalance({ network, tipBotAddress });
-    } catch(e) {
-      log.info(`Failed to check balance on ${network}`, e.message)
+    } catch (e) {
+      log.info(`Failed to check balance on ${network}`, e.message);
     }
   }
 };

--- a/src/balance.ts
+++ b/src/balance.ts
@@ -1,0 +1,29 @@
+import { ApiPromise, WsProvider } from "@polkadot/api";
+import { BN } from "@polkadot/util";
+
+import { getChainConfig } from "./chain-config";
+import { balanceGauge } from "./metrics";
+import { TipNetwork } from "./types";
+
+export const updateAllBalances = async (tipBotAddress: string): Promise<void> => {
+  const networks: TipNetwork[] = ["localpolkadot", "localkusama", "kusama", "polkadot"];
+  for (const network of networks) {
+    await updateBalance({ network, tipBotAddress });
+  }
+};
+
+export const updateBalance = async (opts: { network: TipNetwork; tipBotAddress: string }): Promise<void> => {
+  const { network, tipBotAddress } = opts;
+  const config = getChainConfig(network);
+
+  const provider = new WsProvider(config.providerEndpoint);
+  const api = await ApiPromise.create({ provider });
+  await api.isReady;
+
+  const { data: balances } = await api.query.system.account(tipBotAddress);
+  const balance = balances.free
+    .toBn()
+    .div(new BN(10 ** config.decimals))
+    .toNumber();
+  balanceGauge.set({ network }, balance);
+};

--- a/src/balance.ts
+++ b/src/balance.ts
@@ -4,11 +4,17 @@ import { BN } from "@polkadot/util";
 import { getChainConfig } from "./chain-config";
 import { balanceGauge } from "./metrics";
 import { TipNetwork } from "./types";
+import type { Probot } from "probot";
 
-export const updateAllBalances = async (tipBotAddress: string): Promise<void> => {
+export const updateAllBalances = async (tipBotAddress: string, log: Probot["log"]): Promise<void> => {
   const networks: TipNetwork[] = ["localpolkadot", "localkusama", "kusama", "polkadot"];
   for (const network of networks) {
-    await updateBalance({ network, tipBotAddress });
+    log.info(`Checking tip bot balance on ${network}`)
+    try {
+      await updateBalance({ network, tipBotAddress });
+    } catch(e) {
+      log.info(`Failed to check balance on ${network}`, e.message)
+    }
   }
 };
 
@@ -17,7 +23,7 @@ export const updateBalance = async (opts: { network: TipNetwork; tipBotAddress: 
   const config = getChainConfig(network);
 
   const provider = new WsProvider(config.providerEndpoint);
-  const api = await ApiPromise.create({ provider });
+  const api = await ApiPromise.create({ provider, throwOnConnect: true });
   await api.isReady;
 
   const { data: balances } = await api.query.system.account(tipBotAddress);

--- a/src/balance.ts
+++ b/src/balance.ts
@@ -6,8 +6,14 @@ import { getChainConfig } from "./chain-config";
 import { balanceGauge } from "./metrics";
 import { TipNetwork } from "./types";
 
+/**
+ * The function will update the balances of the tip bot on all networks.
+ * It will skip the local, development networks.
+ * This is intended to be executed upon startup of the bot.
+ * After that, the balances (including local ones) will be updated after a tip is executed.
+ */
 export const updateAllBalances = async (tipBotAddress: string, log: Probot["log"]): Promise<void> => {
-  const networks: TipNetwork[] = ["localpolkadot", "localkusama", "kusama", "polkadot"];
+  const networks: TipNetwork[] = ["kusama", "polkadot"];
   for (const network of networks) {
     log.info(`Checking tip bot balance on ${network}`);
     try {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -160,7 +160,7 @@ const main: AsyncApplicationFunction = async (bot: Probot, { getRouter }) => {
 
   try {
     bot.log.info("Loading bot balances across all networks...");
-    await updateAllBalances(state.botTipAccount.address);
+    await updateAllBalances(state.botTipAccount.address, bot.log);
     bot.log.info("Updated bot balances across all networks!");
   } catch (e) {
     bot.log.error(e.message);

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -8,11 +8,10 @@ const prefix = "tip_bot_";
 promClient.register.setDefaultLabels({ team: "opstooling" });
 promClient.collectDefaultMetrics({ prefix });
 
-const labelNames = ["network", "governance", "result"] as const;
 export const tipCounter = new promClient.Counter({
   name: `${prefix}tips_handled_total`,
   help: "Amount of all tips successfully proposed on-chain.",
-  labelNames,
+  labelNames: ["network", "governance", "result"] as const,
 });
 
 export const recordTip = (opts: { tipRequest: TipRequest; tipResult: TipResult }): void => {
@@ -23,6 +22,12 @@ export const recordTip = (opts: { tipRequest: TipRequest; tipResult: TipResult }
     result: tipResult.success ? "ok" : "fail",
   });
 };
+
+export const balanceGauge = new promClient.Gauge({
+  name: `${prefix}balance`,
+  help: "Balance of the tip bot account",
+  labelNames: ["network"] as const,
+});
 
 export const addMetricsRoute = (router: Router): void => {
   router.get("/metrics", (req, res) => {

--- a/src/tip-opengov.ts
+++ b/src/tip-opengov.ts
@@ -5,7 +5,7 @@ import { KeyringPair } from "@polkadot/keyring/types";
 import { blake2AsHex } from "@polkadot/util-crypto";
 import assert from "assert";
 
-import { getChainConfig } from "./chain-config";
+import { getTipUrl } from "./chain-config";
 import { State, TipRequest, TipResult } from "./types";
 import { formatReason, tipSizeToOpenGovTrack } from "./util";
 
@@ -63,5 +63,5 @@ export async function tipOpenGov(opts: {
       }
     });
 
-  return { success: true, tipUrl: getChainConfig(tipRequest).tipUrl };
+  return { success: true, tipUrl: getTipUrl(tipRequest) };
 }

--- a/src/tip-treasury.ts
+++ b/src/tip-treasury.ts
@@ -2,7 +2,7 @@ import { ApiPromise, SubmittableResult } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
 import assert from "assert";
 
-import { getChainConfig } from "./chain-config";
+import { getTipUrl } from "./chain-config";
 import { State, TipRequest, TipResult } from "./types";
 import { formatReason } from "./util";
 
@@ -35,5 +35,5 @@ export async function tipTreasury(opts: {
       }
     });
 
-  return { success: true, tipUrl: getChainConfig(tipRequest).tipUrl };
+  return { success: true, tipUrl: getTipUrl(tipRequest) };
 }

--- a/src/tip.ts
+++ b/src/tip.ts
@@ -9,7 +9,7 @@ import { State, TipRequest, TipResult } from "./types";
    TODO Unit tests */
 export async function tipUser(state: State, tipRequest: TipRequest): Promise<TipResult> {
   const { bot, botTipAccount } = state;
-  const provider = new WsProvider(getChainConfig(tipRequest).providerEndpoint);
+  const provider = new WsProvider(getChainConfig(tipRequest.contributor.account.network).providerEndpoint);
 
   const api = await ApiPromise.create({ provider });
   await api.isReady;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,6 @@ export type OpenGovTrack = "SmallTipper" | "BigTipper";
 
 export type ChainConfig = {
   providerEndpoint: string;
-  tipUrl: string;
   decimals: number;
   currencySymbol: string;
   smallTipperMaximum: number;

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,7 +30,7 @@ export function getTipSize(tipSizeInput: string | undefined): TipSize | BN {
 }
 
 export function tipSizeToOpenGovTrack(tipRequest: TipRequest): { track: OpenGovTrack; value: BN } | { error: string } {
-  const chainConfig = getChainConfig(tipRequest);
+  const chainConfig = getChainConfig(tipRequest.contributor.account.network);
   const decimalPower = new BN(10).pow(new BN(chainConfig.decimals));
   const tipSize = tipRequest.tip.size;
   const tipValue = BN.isBN(tipSize) ? tipSize : new BN(chainConfig.namedTips[tipSize]);
@@ -91,7 +91,7 @@ export const formatReason = (tipRequest: TipRequest): string => {
  */
 export const formatTipSize = (tipRequest: TipRequest): string => {
   const tipSize = tipRequest.tip.size;
-  const chainConfig = getChainConfig(tipRequest);
+  const chainConfig = getChainConfig(tipRequest.contributor.account.network);
   if (BN.isBN(tipSize)) {
     return `${tipSize.toString()} ${chainConfig.currencySymbol}`;
   }


### PR DESCRIPTION
- Add the balance to the metrics - progresses https://github.com/paritytech/substrate-tip-bot/issues/20
- Fetch balance for all networks on startup, and update it after tip requests
- Some necessary refactors around chain config - `tipUrl` is no longer part of `ChainConfig`, because it depends on a given tip instance