### PR TITLE
Automatically "detect" the governance of the chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ guidance
 
 ### Integration tests
 
-There are semi-automatic integration tests that execute the tip functions against a locally running Polkadot node.
+There are semi-automatic integration tests that execute the tip functions against a locally running Polkadot and Kusama nodes.
+
+| Network        | Snippet |
+|----------------| --- |
+| Local Kusama   | `docker run --rm -p 9901:9901 parity/polkadot:v0.9.39 --chain=kusama-dev --tmp --alice --execution Native --ws-port 9901 --ws-external --force-kusama` |
+| Local Polkadot | `docker run --rm -p 9900:9900 parity/polkadot:v0.9.39 --chain=dev --tmp --alice --execution Native --ws-port 9900 --ws-external` |
+
 Note that the node needs to have the OpenGov features - Kusama development chain can be used for that (`--chain=kusama-dev`).
 
 With that, run the tests:

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -64,7 +64,7 @@ const onIssueComment = async (
     contributor: { githubUsername: contributorLogin, account: contributorAccount },
     pullRequestNumber,
     pullRequestRepo,
-    tip: { size: tipSize, type: botMention === "/tip2" ? "opengov" : "treasury" },
+    tip: { size: tipSize },
   };
 
   bot.log(

--- a/src/chain-config.ts
+++ b/src/chain-config.ts
@@ -1,6 +1,6 @@
 import { ChainConfig, TipNetwork } from "./types";
 
-type Constants = Omit<ChainConfig, "providerEndpoint" | "tipUrl">;
+type Constants = Omit<ChainConfig, "providerEndpoint">;
 const kusamaConstants: Constants = {
   decimals: 12,
   currencySymbol: "KSM",

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -8,7 +8,7 @@ const prefix = "tip_bot_";
 promClient.register.setDefaultLabels({ team: "opstooling" });
 promClient.collectDefaultMetrics({ prefix });
 
-const labelNames = ["network", "governance", "result"] as const;
+const labelNames = ["network", "result"] as const;
 export const tipCounter = new promClient.Counter({
   name: `${prefix}tips_handled_total`,
   help: "Amount of all tips successfully proposed on-chain.",
@@ -17,11 +17,7 @@ export const tipCounter = new promClient.Counter({
 
 export const recordTip = (opts: { tipRequest: TipRequest; tipResult: TipResult }): void => {
   const { tipRequest, tipResult } = opts;
-  tipCounter.inc({
-    network: tipRequest.contributor.account.network,
-    governance: tipRequest.tip.type,
-    result: tipResult.success ? "ok" : "fail",
-  });
+  tipCounter.inc({ network: tipRequest.contributor.account.network, result: tipResult.success ? "ok" : "fail" });
 };
 
 export const addMetricsRoute = (router: Router): void => {

--- a/src/tip-opengov.ts
+++ b/src/tip-opengov.ts
@@ -22,7 +22,8 @@ export async function tipOpenGov(opts: {
     botTipAccount,
   } = opts;
   const { contributor } = tipRequest;
-  assert(tipRequest.tip.type === "opengov");
+  const chainConfig = getChainConfig(contributor.account.network);
+  assert(chainConfig.tipType === "opengov");
 
   const track = tipSizeToOpenGovTrack(tipRequest);
   if ("error" in track) {
@@ -63,5 +64,5 @@ export async function tipOpenGov(opts: {
       }
     });
 
-  return { success: true, tipUrl: getChainConfig(tipRequest).tipUrl };
+  return { success: true, tipUrl: chainConfig.tipUrl };
 }

--- a/src/tip-treasury.ts
+++ b/src/tip-treasury.ts
@@ -18,8 +18,9 @@ export async function tipTreasury(opts: {
     tipRequest,
     botTipAccount,
   } = opts;
-  const { contributor, tip } = tipRequest;
-  assert(tip.type === "treasury");
+  const { contributor } = tipRequest;
+  const chainConfig = getChainConfig(contributor.account.network);
+  assert(chainConfig.tipType === "treasury");
 
   /* TODO before submitting, check tip does not already exist via a storage query.
          TODO potentially prevent duplicates by also checking for reasons with the other sizes. */
@@ -35,5 +36,5 @@ export async function tipTreasury(opts: {
       }
     });
 
-  return { success: true, tipUrl: getChainConfig(tipRequest).tipUrl };
+  return { success: true, tipUrl: chainConfig.tipUrl };
 }

--- a/src/tip.test.ts
+++ b/src/tip.test.ts
@@ -109,8 +109,9 @@ describe("tip", () => {
         const result = await tipUser(state, tipRequest);
 
         if (network === "localpolkadot") {
-          /* Currently we don't impose hard constraints on the tip value,
-             as there are no 'tracks' in trasury tips with maximum values like in opengov.
+          /* Polkadot doesn't have OpenGov (yet).
+             Currently, we don't impose hard constraints on the tip value,
+             as there are no 'tracks' in treasury tips with maximum values like in opengov.
              The values in treasure tips have no direct programmatic effect,
              they are just a textual suggestions for the tippers. */
           expect(result.success).toBeTruthy();

--- a/src/tip.ts
+++ b/src/tip.ts
@@ -9,7 +9,8 @@ import { State, TipRequest, TipResult } from "./types";
    TODO Unit tests */
 export async function tipUser(state: State, tipRequest: TipRequest): Promise<TipResult> {
   const { bot, botTipAccount } = state;
-  const provider = new WsProvider(getChainConfig(tipRequest).providerEndpoint);
+  const chainConfig = getChainConfig(tipRequest.contributor.account.network);
+  const provider = new WsProvider(chainConfig.providerEndpoint);
 
   const api = await ApiPromise.create({ provider });
   await api.isReady;
@@ -24,7 +25,7 @@ export async function tipUser(state: State, tipRequest: TipRequest): Promise<Tip
   bot.log(`You are connected to chain ${chain.toString()} using ${nodeName.toString()} v${nodeVersion.toString()}`);
 
   try {
-    switch (tipRequest.tip.type) {
+    switch (chainConfig.tipType) {
       case "treasury": {
         return await tipTreasury({ state, api, tipRequest, botTipAccount });
         break;
@@ -34,7 +35,7 @@ export async function tipUser(state: State, tipRequest: TipRequest): Promise<Tip
         break;
       }
       default: {
-        const exhaustivenessCheck: never = tipRequest.tip.type;
+        const exhaustivenessCheck: never = chainConfig.tipType;
         throw new Error(
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           `Invalid tip type: "${exhaustivenessCheck}"`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,12 +4,20 @@ import { Probot } from "probot";
 
 export type TipNetwork = "localkusama" | "localpolkadot" | "kusama" | "polkadot";
 
+export type TipType = "treasury" | "opengov";
 export type TipSize = "small" | "medium" | "large";
 export type OpenGovTrack = "SmallTipper" | "BigTipper";
 
 export type ChainConfig = {
   providerEndpoint: string;
   tipUrl: string;
+
+  /**
+   * This is dependent on which pallets the chain has.
+   * The preferred type is OpenGov,
+   * but some chains (Polkadot) do not support it (yet).
+   */
+  tipType: TipType;
   decimals: number;
   currencySymbol: string;
   smallTipperMaximum: number;
@@ -39,7 +47,6 @@ export type TipRequest = {
   pullRequestNumber: number;
   pullRequestRepo: string;
   tip: {
-    type: "treasury" | "opengov";
     size: TipSize | BN;
   };
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,7 +30,7 @@ export function getTipSize(tipSizeInput: string | undefined): TipSize | BN {
 }
 
 export function tipSizeToOpenGovTrack(tipRequest: TipRequest): { track: OpenGovTrack; value: BN } | { error: string } {
-  const chainConfig = getChainConfig(tipRequest);
+  const chainConfig = getChainConfig(tipRequest.contributor.account.network);
   const decimalPower = new BN(10).pow(new BN(chainConfig.decimals));
   const tipSize = tipRequest.tip.size;
   const tipValue = BN.isBN(tipSize) ? tipSize : new BN(chainConfig.namedTips[tipSize]);
@@ -91,7 +91,7 @@ export const formatReason = (tipRequest: TipRequest): string => {
  */
 export const formatTipSize = (tipRequest: TipRequest): string => {
   const tipSize = tipRequest.tip.size;
-  const chainConfig = getChainConfig(tipRequest);
+  const chainConfig = getChainConfig(tipRequest.contributor.account.network);
   if (BN.isBN(tipSize)) {
     return `${tipSize.toString()} ${chainConfig.currencySymbol}`;
   }


### PR DESCRIPTION
- Progresses https://github.com/paritytech/substrate-tip-bot/issues/39
- Automatically "detects" whether the target chain supports OpenGov or Treasury Tips
  - This is done in a "dumb" way by specifying a chain config option. The reasoning is that soon, OpenGov will be added to Polkadot, and we will remove gov1 tips from the tip bot, only use OpenGov, and no "smart" detection mechanism will be needed.
  - Now there is a single command - `/tip`. `/tip2` is no longer there.
- Updated integrations tests to use two chains.