### PR TITLE
Specify delay and period for healthchecks

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -26,10 +26,14 @@ common:
    httpGet:
      path: /tip-bot/health
      port: http
+   initialDelaySeconds: 60
+   periodSeconds: 5
   readinessProbe:
    httpGet:
      path: /tip-bot/health
      port: http
+   initialDelaySeconds: 60
+   periodSeconds: 5
   serviceMonitor:
     enabled: true
     endpoints:


### PR DESCRIPTION
I've looked at the logs in staging&prod and it looks like the bot is being spammed with healthchecks multiple times a second.