### PR TITLE
Throw on connection failure

### DIFF
--- a/src/tip.ts
+++ b/src/tip.ts
@@ -12,8 +12,8 @@ export async function tipUser(state: State, tipRequest: TipRequest): Promise<Tip
   const chainConfig = getChainConfig(tipRequest.contributor.account.network);
   const provider = new WsProvider(chainConfig.providerEndpoint);
 
-  const api = await ApiPromise.create({ provider });
-  await api.isReady;
+  const api = await ApiPromise.create({ provider, throwOnConnect: true });
+  await api.isReadyOrError;
 
   // Get general information about the node we are connected to
   const [chain, nodeName, nodeVersion] = await Promise.all([


### PR DESCRIPTION
Without that, when the API is not available, the bot hangs trying to connect forever and never responds back to the user.

With this change, the bot will post a comment about an error.