### PR TITLE
Introduce an E2E tests for an opengov tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,29 @@ $ docker run \
     substrate-tip-bot
 ```
 
+## End-to-end tests
+
+For the E2E tests, we need a modified Kusama node in a way that speeds up the referenda and treasury.
+
+### Preparing and running Kusama
+
+```bash
+git clone https://github.com/paritytech/polkadot.git
+cd polkadot
+git checkout v0.9.42
+git apply ../polkadot.e2e.patch
+cargo build --release --locked --features=fast-runtime -p polkadot
+./target/release/polkadot --ws-external --rpc-external --no-prometheus --no-telemetry --chain=kusama-dev --tmp --alice --execution Native --ws-port 9901 --force-kusama
+```
+
+### Running the E2E tests
+
+```bash
+yarn test:e2e
+```
+
+Go make a cup of tea, the tests take ~4 minutes (waiting for the various on-chain stages to pass).
+
 ## Contributing
 
 If you have suggestions for how substrate-tip-bot could be improved, or want to report a bug, open

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -1,0 +1,4 @@
+const commonConfig = require("./jest.config.js");
+
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = { ...commonConfig, testMatch: ["**/?(*.)+(e2e).[jt]s?(x)"], testTimeout: 10 * 60_000 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "fix": "yarn fix:eslint '{*,**/*}.{js,ts}' && yarn fix:prettier '{*,**/*}.json'",
     "start": "nodemon",
     "build": "rimraf dist; babel src/ --extensions '.ts,.js' --out-dir dist/",
-    "test": "NODE_OPTIONS='--experimental-vm-modules --es-module-specifier-resolution=node' jest"
+    "test": "NODE_OPTIONS='--experimental-vm-modules --es-module-specifier-resolution=node' jest",
+    "test:e2e": "NODE_OPTIONS='--experimental-vm-modules --es-module-specifier-resolution=node' jest -c jest.e2e.config.js"
   },
   "dependencies": {
     "@polkadot/api": "^10.7.1",

--- a/polkadot.e2e.patch
+++ b/polkadot.e2e.patch
@@ -1,0 +1,50 @@
+diff --git a/runtime/kusama/src/governance/mod.rs b/runtime/kusama/src/governance/mod.rs
+index c8a7b360ed..78bd7fbe67 100644
+--- a/runtime/kusama/src/governance/mod.rs
++++ b/runtime/kusama/src/governance/mod.rs
+@@ -35,7 +35,7 @@ mod fellowship;
+ pub use fellowship::{FellowshipCollectiveInstance, FellowshipReferendaInstance};
+ 
+ parameter_types! {
+-	pub const VoteLockingPeriod: BlockNumber = 7 * DAYS;
++	pub const VoteLockingPeriod: BlockNumber = 1 * MINUTES;
+ }
+ 
+ impl pallet_conviction_voting::Config for Runtime {
+@@ -52,7 +52,7 @@ impl pallet_conviction_voting::Config for Runtime {
+ parameter_types! {
+ 	pub const AlarmInterval: BlockNumber = 1;
+ 	pub const SubmissionDeposit: Balance = 1 * QUID;
+-	pub const UndecidingTimeout: BlockNumber = 14 * DAYS;
++	pub const UndecidingTimeout: BlockNumber = 20 * MINUTES;
+ }
+ 
+ parameter_types! {
+diff --git a/runtime/kusama/src/governance/tracks.rs b/runtime/kusama/src/governance/tracks.rs
+index 08a87a677c..2f556e9602 100644
+--- a/runtime/kusama/src/governance/tracks.rs
++++ b/runtime/kusama/src/governance/tracks.rs
+@@ -213,8 +213,8 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15
+ 			max_deciding: 200,
+ 			decision_deposit: 1 * QUID,
+ 			prepare_period: 1 * MINUTES,
+-			decision_period: 7 * DAYS,
+-			confirm_period: 10 * MINUTES,
++			decision_period: 1 * MINUTES,
++			confirm_period: 1 * MINUTES,
+ 			min_enactment_period: 1 * MINUTES,
+ 			min_approval: APP_SMALL_TIPPER,
+ 			min_support: SUP_SMALL_TIPPER,
+diff --git a/runtime/kusama/src/lib.rs b/runtime/kusama/src/lib.rs
+index 35dc79a4b5..07acab5014 100644
+--- a/runtime/kusama/src/lib.rs
++++ b/runtime/kusama/src/lib.rs
+@@ -606,7 +606,7 @@ parameter_types! {
+ 	pub const ProposalBond: Permill = Permill::from_percent(5);
+ 	pub const ProposalBondMinimum: Balance = 2000 * CENTS;
+ 	pub const ProposalBondMaximum: Balance = 1 * GRAND;
+-	pub const SpendPeriod: BlockNumber = 6 * DAYS;
++	pub const SpendPeriod: BlockNumber = 1 * MINUTES;
+ 	pub const Burn: Permill = Permill::from_perthousand(2);
+ 	pub const TreasuryPalletId: PalletId = PalletId(*b"py/trsry");
+ 

--- a/src/tip-opengov.e2e.ts
+++ b/src/tip-opengov.e2e.ts
@@ -1,0 +1,97 @@
+/*
+This is an E2E test for an opengov tip,
+from the point of creating a tip,
+all the way to completing the referendum.
+ */
+
+import "@polkadot/api-augment";
+import { ApiPromise, Keyring, WsProvider } from "@polkadot/api";
+import { createTestKeyring } from "@polkadot/keyring";
+import { KeyringPair } from "@polkadot/keyring/types";
+import { BN } from "@polkadot/util";
+import { cryptoWaitReady, randomAsU8a } from "@polkadot/util-crypto";
+import assert from "assert";
+
+import { getChainConfig } from "./chain-config";
+import { tipUser } from "./tip";
+import { State, TipRequest } from "./types";
+
+const randomAddress = () => createTestKeyring().addFromSeed(randomAsU8a(32)).address;
+
+const logMock: any = console.log.bind(console); // eslint-disable-line @typescript-eslint/no-explicit-any
+logMock.error = console.error.bind(console);
+
+const tipperAccount = "14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3"; // Bob
+
+describe("E2E opengov tip", () => {
+  let state: State;
+  let kusamaApi: ApiPromise;
+  let alice: KeyringPair;
+
+  beforeAll(() => {
+    kusamaApi = new ApiPromise({
+      provider: new WsProvider(getChainConfig("localkusama").providerEndpoint),
+      types: { Address: "AccountId", LookupSource: "AccountId" },
+    });
+  });
+
+  afterAll(async () => {
+    await kusamaApi.disconnect();
+  });
+
+  const getUserBalance = async (userAddress: string) => {
+    const { data } = await kusamaApi.query.system.account(userAddress);
+    return data.free.toBn();
+  };
+
+  beforeAll(async () => {
+    await cryptoWaitReady();
+    const keyring = new Keyring({ type: "sr25519" });
+    try {
+      await kusamaApi.isReadyOrError;
+    } catch (e) {
+      console.log(
+        `For these integrations tests, we're expecting local Kusama on ${
+          getChainConfig("localkusama").providerEndpoint
+        }. Please refer to the Readme.`,
+      );
+    }
+
+    assert((await getUserBalance(tipperAccount)).gtn(0));
+    state = {
+      allowedGitHubOrg: "test",
+      allowedGitHubTeam: "test",
+      botTipAccount: keyring.addFromUri("//Bob"),
+      bot: { log: logMock } as any, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+    };
+    alice = keyring.addFromUri("//Alice");
+  });
+
+  test("Small OpenGov tip", async () => {
+    const referendumId = await kusamaApi.query.referenda.referendumCount(); // The next free referendum index.
+    const tipRequest: TipRequest = {
+      tip: { size: "small" },
+      contributor: { githubUsername: "test", account: { address: randomAddress(), network: "localkusama" } },
+      pullRequestRepo: "test",
+      pullRequestNumber: 1,
+    };
+    // It is a random new address, so we expect the balance to be zero initially.
+    expect((await getUserBalance(tipRequest.contributor.account.address)).eqn(0)).toBeTruthy();
+
+    // We place the tip proposal.
+    const result = await tipUser(state, tipRequest);
+    expect(result.success).toBeTruthy();
+
+    // Alice votes "aye" on the referendum.
+    await kusamaApi.tx.referenda.placeDecisionDeposit(referendumId).signAndSend(alice, { nonce: -1 });
+    await kusamaApi.tx.convictionVoting
+      .vote(referendumId, { Standard: { balance: new BN(1_000_000), vote: { aye: true, conviction: 1 } } })
+      .signAndSend(alice, { nonce: -1 });
+
+    // Going to sleep for 4 minutes, waiting for the referendum voting, enactment, and treasury spend period.
+    await new Promise((res) => setTimeout(res, 4 * 60_000));
+
+    // At the end, the balance of the contributor should increase.
+    expect((await getUserBalance(tipRequest.contributor.account.address)).eqn(2 * 10 ** 12)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
This introduces a test for an opengov tip, with a local Kusama node.

- First, we run a modified Kusama node.
- The modifications shorten the time of the referendum, and speed up treasury spend period. They are in a form of a git patch.
- Then, we send the tip proposal, vote `aye` with a different account, wait for all the phases to go through and assert the balance of the beneficiary.
- It is NOT run on CI. (maybe in the future?)