### PR TITLE
Use polkadot.js getter to determine extrinsic error

### DIFF
--- a/src/tip-opengov.ts
+++ b/src/tip-opengov.ts
@@ -116,12 +116,7 @@ async function signAndSendCallback(
       bot.log(`Tip for ${contributor.address} ${type} finalized at blockHash ${result.status.asFinalized.toString()}`);
       unsubscribe();
       resolve({ success: true, tipUrl: getTipUrl(contributor.network) });
-    } else if (
-      result.status.isDropped ||
-      result.status.isInvalid ||
-      result.status.isUsurped ||
-      result.status.isRetracted
-    ) {
+    } else if (result.isError) {
       bot.log(`status to string`, result.status.toString());
       bot.log(`result.toHuman`, result.toHuman());
       bot.log(`result`, result);


### PR DESCRIPTION
The `isError` is defined here:

https://github.com/polkadot-js/api/blob/edde226740341396bc59bf96ad38ea559357bb9d/packages/api/src/submittable/Result.ts#L69-L71

I just had an `isRetracted` status but the extrinsic eventually went through, so the current definition is incorrect.