### PR TITLE
Remove a log that was too verbose

### DIFF
--- a/src/tip-opengov.ts
+++ b/src/tip-opengov.ts
@@ -122,7 +122,7 @@ async function signAndSendCallback(
       bot.log(msg, result.status);
       reject({ success: false, errorMessage: msg });
     } else {
-      bot.log(`Tip for ${contributor.address} ${type} status: ${result.status.type}`, result.status);
+      bot.log(`Tip for ${contributor.address} ${type} status: ${result.status.type}`);
     }
   });
 }


### PR DESCRIPTION
The `result.status` turned out to be an object that prints out dozens of internal things, so it turned out to be a bad thing to log.

<img width="846" alt="Screenshot 2023-06-20 at 11 46 06" src="https://github.com/paritytech/substrate-tip-bot/assets/12039224/b5e3958f-e06e-4668-96ee-7ad3db7da9e8">
