### PR TITLE
Remove obsolete variable

### DIFF
--- a/helm/values-parity-stg.yaml
+++ b/helm/values-parity-stg.yaml
@@ -1,7 +1,6 @@
 common:
   env:
     APP_HOST: "https://substrate-tip-bot.parity-stg.parity.io"
-    DATABASE_NAME: "substrate-tip-bot"
     APPROVERS_GH_ORG: "paritytech-stg"
     APPROVERS_GH_TEAM: "tip-bot-approvers"
     POLKASSEMBLY_ENDPOINT: "https://test.polkassembly.io/api/v1/"


### PR DESCRIPTION
It doesn't appear to be used.
`values-parity-prod` doesn't have this variable.