### PR TITLE
Inline the preimages in the referendum

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -133,3 +133,6 @@ export const formatTipSize = (tipRequest: TipRequest): string => {
  * It is used to tag these usernames when there is a failure.
  */
 export const teamMatrixHandles = ["@przemek", "@mak", "@yuri", "@bullrich"];
+
+// https://stackoverflow.com/a/52254083
+export const byteSize = (str: string): number => new Blob([str]).size;


### PR DESCRIPTION
- Closes https://github.com/paritytech/substrate-tip-bot/issues/76
- Closes https://github.com/paritytech/substrate-tip-bot/issues/73 - no preimages, no cleanup necessary
- Closes https://github.com/paritytech/substrate-tip-bot/issues/65 - no preimages to test, also we have an E2E tests that makes sure that everything is constructed properly