### PR TITLE
Disconnect ApiPromise after balance check

### DIFF
--- a/src/balance.ts
+++ b/src/balance.ts
@@ -32,10 +32,17 @@ export const updateBalance = async (opts: { network: TipNetwork; tipBotAddress: 
   const api = await ApiPromise.create({ provider, throwOnConnect: true });
   await api.isReady;
 
-  const { data: balances } = await api.query.system.account(tipBotAddress);
-  const balance = balances.free
-    .toBn()
-    .div(new BN(10 ** config.decimals))
-    .toNumber();
-  balanceGauge.set({ network }, balance);
+  try {
+    const { data: balances } = await api.query.system.account(tipBotAddress);
+    const balance = balances.free
+      .toBn()
+      .div(new BN(10 ** config.decimals))
+      .toNumber();
+    balanceGauge.set({ network }, balance);
+  } catch (e) {
+    throw e;
+  } finally {
+    await api.disconnect();
+    await provider.disconnect();
+  }
 };

--- a/src/balance.ts
+++ b/src/balance.ts
@@ -39,8 +39,6 @@ export const updateBalance = async (opts: { network: TipNetwork; tipBotAddress: 
       .div(new BN(10 ** config.decimals))
       .toNumber();
     balanceGauge.set({ network }, balance);
-  } catch (e) {
-    throw e;
   } finally {
     await api.disconnect();
     await provider.disconnect();


### PR DESCRIPTION
This might help with https://github.com/paritytech/substrate-tip-bot/issues/11
(Not closing, I'm going to observe it for a while because I don't have a way to consistently reproduce the error locally).

I believe the issue might have been fixed by adding a disconnect:

https://github.com/paritytech/substrate-tip-bot/blob/374ce68097fa063f2322b77964e73122d93cfba5/src/tip.ts#L32

And then re-introduced by adding a separate ApiPromise in the balance check without disconnecting.