### PR TITLE
Add a missing error handler around transaction sending

### DIFF
--- a/src/tip-opengov.ts
+++ b/src/tip-opengov.ts
@@ -40,18 +40,22 @@ export async function tipOpenGov(opts: { state: State; api: ApiPromise; tipReque
 
   const referendumId = await api.query.referenda.referendumCount(); // The next free referendum index.
   const tipResult = await new Promise<TipResult>(async (resolve, reject) => {
-    const proposalUnsubscribe = await api.tx.referenda
-      .submit(
-        // TODO: There should be a way to set those types properly.
-        { Origins: track.track.trackName } as never,
-        { Inline: encodedProposal },
-        { after: 10 } as never,
-      )
-      .signAndSend(botTipAccount, async (refResult) => {
-        await signAndSendCallback(bot, contributor.account, "referendum", proposalUnsubscribe, refResult)
-          .then(resolve)
-          .catch(reject);
-      });
+    try {
+      const proposalUnsubscribe = await api.tx.referenda
+        .submit(
+          // TODO: There should be a way to set those types properly.
+          { Origins: track.track.trackName } as never,
+          { Inline: encodedProposal },
+          { after: 10 } as never,
+        )
+        .signAndSend(botTipAccount, async (refResult) => {
+          await signAndSendCallback(bot, contributor.account, "referendum", proposalUnsubscribe, refResult)
+            .then(resolve)
+            .catch(reject);
+        });
+    } catch (e) {
+      reject(e);
+    }
   });
 
   if (tipResult.success && polkassembly) {


### PR DESCRIPTION
We handle the rejection of `signAndSendCallback` passed to the `signAndSend` function, but the failure of `signAndSend` itself is not handled.

I experienced an unhandled promise rejection when trying to send a transaction with an account with no funds - it crashed the whole app.

This fixes it, and the app is able to continue and notify on github&matrix about the error.