### PR TITLE
Various refactorings of the `bot-handle-comment.ts` file

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:e2e": "NODE_OPTIONS='--experimental-vm-modules --es-module-specifier-resolution=node' jest -c jest.e2e.config.js"
   },
   "dependencies": {
-    "@eng-automation/integrations": "^4.0.0",
+    "@eng-automation/integrations": "^4.1.0",
     "@eng-automation/js": "^0.0.22",
     "@polkadot/api": "^10.9.1",
     "@polkadot/util": "^12.3.2",

--- a/src/bot-handle-comment.ts
+++ b/src/bot-handle-comment.ts
@@ -38,13 +38,11 @@ export const handleIssueCommentCreated = async (state: State, event: IssueCommen
     issue_number: event.issue.number,
   };
 
-  const githubEmojiReaction = async (reaction: GithubReactionType) => {
-    await octokitInstance.rest.reactions.createForIssueComment({
-      ...respondParams,
-      comment_id: event.comment.id,
-      content: reaction,
-    });
-  };
+  const githubEmojiReaction = async (reaction: GithubReactionType) =>
+    await github.createReactionForIssueComment(
+      { ...respondParams, comment_id: event.comment.id, content: reaction },
+      { octokitInstance },
+    );
 
   const UNKNOWN_ERROR_MSG = `@${tipRequester} Could not submit tip :( The team has been notified. Alternatively open an issue [here](https://github.com/paritytech/substrate-tip-bot/issues/new).`;
 

--- a/src/bot-handle-comment.ts
+++ b/src/bot-handle-comment.ts
@@ -46,7 +46,7 @@ export const handleIssueCommentCreated = async (state: State, event: IssueCommen
     });
   };
 
-  const UNKNOWN_ERROR_MSG = `@${tipRequester} Could not submit tip :( The team has been notified. Alternatively open an issue [here](https://github.com/paritytech/substrate-tip-bot/issues/new).`
+  const UNKNOWN_ERROR_MSG = `@${tipRequester} Could not submit tip :( The team has been notified. Alternatively open an issue [here](https://github.com/paritytech/substrate-tip-bot/issues/new).`;
 
   const respondOnResult = async (result: OnIssueCommentResult) => {
     let body: string;
@@ -73,13 +73,7 @@ export const handleIssueCommentCreated = async (state: State, event: IssueCommen
   const respondOnUnknownError = async (e: Error) => {
     state.bot.log.error(e.message);
     await matrixNotifyOnFailure(state.matrix, event);
-    await github.createComment(
-      {
-        ...respondParams,
-        body: UNKNOWN_ERROR_MSG,
-      },
-      { octokitInstance },
-    );
+    await github.createComment({ ...respondParams, body: UNKNOWN_ERROR_MSG }, { octokitInstance });
     await githubEmojiReaction("confused");
   };
 
@@ -172,9 +166,6 @@ export const handleTipRequest = async (
       }). \n\n ${tipResult.tipUrl} ![tip](https://c.tenor.com/GdyQm7LX3h4AAAAi/mlady-fedora.gif)`,
     };
   } else {
-    return {
-      type: "error",
-      errorMessage: tipResult.errorMessage,
-    };
+    return { type: "error", errorMessage: tipResult.errorMessage };
   }
 };

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -1,0 +1,33 @@
+import { IssueCommentCreatedEvent } from "@octokit/webhooks-types";
+
+import { State } from "./types";
+import { teamMatrixHandles } from "./util";
+
+export const sendMatrixMessage = async (
+  matrix: State["matrix"],
+  opts: { text: string; html: string },
+): Promise<void> => {
+  await matrix?.client.sendMessage(matrix.roomId, {
+    body: opts.text,
+    format: "org.matrix.custom.html",
+    formatted_body: opts.html,
+    msgtype: "m.text",
+  });
+};
+
+export const matrixNotifyOnNewTip = async (matrix: State["matrix"], event: IssueCommentCreatedEvent): Promise<void> => {
+  await sendMatrixMessage(matrix, {
+    text: `A new tip has been requested: ${event.comment.html_url}`,
+    html: `A new tip has been <a href="${event.comment.html_url}">requested</a>.`,
+  });
+};
+
+export const matrixNotifyOnFailure = async (
+  matrix: State["matrix"],
+  event: IssueCommentCreatedEvent,
+): Promise<void> => {
+  await sendMatrixMessage(matrix, {
+    text: `${teamMatrixHandles.join(" ")} A tip has failed: ${event.comment.html_url}`,
+    html: `${teamMatrixHandles.join(" ")} A tip has <a href="${event.comment.html_url}">failed</a>!`,
+  });
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,3 +57,6 @@ export type TipRequest = {
 export type TipResult =
   | { success: true; tipUrl: string; blockHash: string }
   | { success: false; errorMessage?: string };
+
+// https://docs.github.com/en/rest/reactions/reactions#about-reactions
+export type GithubReactionType = "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";

--- a/yarn.lock
+++ b/yarn.lock
@@ -501,10 +501,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@eng-automation/integrations@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@eng-automation/integrations/-/integrations-4.0.0.tgz#5e11e095c52f43f2381babd7410d23d8c2e36b42"
-  integrity sha512-o/G/BU3VUirxrFsvK6UywoauS0odoOM8nL1QufxvhRHWTc+WKuShxhnpkM89VHXm654vNqj+YGykME7EF0KW7Q==
+"@eng-automation/integrations@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@eng-automation/integrations/-/integrations-4.1.0.tgz#aad30db084dcef6ea7827ac3f856d722e828e49b"
+  integrity sha512-0ezJu6MSQOKAEfczZhz5GB1JCVUSnYCiMMFxBsy+/zcNs67s206js1nt5IdN5ROEFwC2XoPwY9iDkkHA8dqwyg==
   dependencies:
     "@eng-automation/js" "^0.0.21"
     "@octokit/auth-app" "^4.0.7"


### PR DESCRIPTION
- [Extract github emoji logic into a helper function `githubEmojiReaction`](https://github.com/paritytech/substrate-tip-bot/commit/4c3eb907206aedd819650830827a3ae602ded918)
- [Extract the matrix notification logic into a separate file](https://github.com/paritytech/substrate-tip-bot/commit/7e11ca8d2af9d2a5ba3687df3d3b743f38e825fe)
- [Extract the error message of an unkown error into a variable, because it was duplicated](https://github.com/paritytech/substrate-tip-bot/commit/044e19f3fd064c0cffd76bfcec94ede8b40062fa)
- The goal is to improve the readability of the file