### PR TITLE
Refactor the flow of `bot-handle-comment.ts`

### DIFF
--- a/src/tip.ts
+++ b/src/tip.ts
@@ -25,9 +25,6 @@ export async function tipUser(state: State, tipRequest: TipRequest): Promise<Tip
 
   try {
     return await tipOpenGov({ state, api, tipRequest });
-  } catch (e) {
-    bot.log.error(e.message);
-    return { success: false };
   } finally {
     await api.disconnect();
     await provider.disconnect();

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,9 +54,7 @@ export type TipRequest = {
   };
 };
 
-export type TipResult =
-  | { success: true; tipUrl: string; blockHash: string }
-  | { success: false; errorMessage?: string };
+export type TipResult = { success: true; tipUrl: string; blockHash: string } | { success: false; errorMessage: string };
 
 // https://docs.github.com/en/rest/reactions/reactions#about-reactions
 export type GithubReactionType = "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -8,6 +8,9 @@ describe("Utility functions", () => {
     test("Can parse the account", () => {
       const address = randomAddress();
       const result = parseContributorAccount([`kusama address: ${address}`]);
+      if ("error" in result) {
+        throw new Error(result.error);
+      }
       expect(result.network).toEqual("kusama");
       expect(result.address).toEqual(address);
     });
@@ -28,6 +31,9 @@ describe("Utility functions", () => {
       const addressA = randomAddress();
       const addressB = randomAddress();
       const result = parseContributorAccount([`kusama address: ${addressA}`, `polkadot address: ${addressB}`]);
+      if ("error" in result) {
+        throw new Error(result.error);
+      }
       expect(result.network).toEqual("kusama");
       expect(result.address).toEqual(addressA);
     });
@@ -38,12 +44,18 @@ describe("Utility functions", () => {
 
       {
         const result = parseContributorAccount([`kusama: ${addressA}`, `polkadot address: ${addressB}`]);
+        if ("error" in result) {
+          throw new Error(result.error);
+        }
         expect(result.network).toEqual("polkadot");
         expect(result.address).toEqual(addressB);
       }
 
       {
         const result = parseContributorAccount([null, `polkadot address: ${addressB}`]);
+        if ("error" in result) {
+          throw new Error(result.error);
+        }
         expect(result.network).toEqual("polkadot");
         expect(result.address).toEqual(addressB);
       }

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -21,7 +21,7 @@ describe("Utility functions", () => {
       if (!("error" in result)) {
         throw new Error("Expected error message not found.");
       }
-      expect(result.error).toEqual("Contributor did not properly post their account address");
+      expect(result.error).toMatch("Contributor did not properly post their account address");
     });
 
     test("Throws on invalid network", () => {

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -30,7 +30,7 @@ describe("Utility functions", () => {
       if (!("error" in result)) {
         throw new Error("Expected error message not found.");
       }
-      expect(result.error).toEqual("Invalid network");
+      expect(result.error).toMatch("Invalid network");
     });
 
     test("First body takes precedence over following bodies", () => {
@@ -74,7 +74,7 @@ describe("Utility functions", () => {
       if (!("error" in result)) {
         throw new Error("Expected error message not found.");
       }
-      expect(result.error).toEqual("Invalid network");
+      expect(result.error).toMatch("Invalid network");
     });
   });
 });

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -15,16 +15,22 @@ describe("Utility functions", () => {
       expect(result.address).toEqual(address);
     });
 
-    test("Throws when cannot parse", () => {
+    test("Returns error message when cannot parse", () => {
       const address = randomAddress();
-      expect(() => parseContributorAccount([`kusama: ${address}`])).toThrowError(
-        "Contributor did not properly post their account address",
-      );
+      const result = parseContributorAccount([`kusama: ${address}`]);
+      if (!("error" in result)) {
+        throw new Error("Expected error message not found.");
+      }
+      expect(result.error).toEqual("Contributor did not properly post their account address");
     });
 
     test("Throws on invalid network", () => {
       const address = randomAddress();
-      expect(() => parseContributorAccount([`kussama address: ${address}`])).toThrowError("Invalid network");
+      const result = parseContributorAccount([`kussama address: ${address}`]);
+      if (!("error" in result)) {
+        throw new Error("Expected error message not found.");
+      }
+      expect(result.error).toEqual("Invalid network");
     });
 
     test("First body takes precedence over following bodies", () => {
@@ -64,9 +70,11 @@ describe("Utility functions", () => {
     test("Throws when the first body has invalid network", () => {
       const addressA = randomAddress();
       const addressB = randomAddress();
-      expect(() =>
-        parseContributorAccount([`kussama address: ${addressA}`, `polkadot address: ${addressB}`]),
-      ).toThrowError("Invalid network");
+      const result = parseContributorAccount([`kussama address: ${addressA}`, `polkadot address: ${addressB}`]);
+      if (!("error" in result)) {
+        throw new Error("Expected error message not found.");
+      }
+      expect(result.error).toEqual("Invalid network");
     });
   });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,9 +23,9 @@ const validNetworks: { [key: string]: TipNetwork } = {
   localpolkadot: "localpolkadot",
 } as const;
 
-export function getTipSize(tipSizeInput: string | undefined): TipSize | BN {
+export function getTipSize(tipSizeInput: string | undefined): TipSize | BN | { error: string } {
   if (tipSizeInput === undefined || tipSizeInput.length === 0) {
-    throw new Error("Tip size not specified");
+    return { error: "Tip size not specified" };
   }
 
   try {
@@ -34,7 +34,7 @@ export function getTipSize(tipSizeInput: string | undefined): TipSize | BN {
   } catch {}
 
   if (!tipSizeInput || !(tipSizeInput in validTipSizes)) {
-    throw new Error(`Invalid tip size. Please specify one of ${Object.keys(validTipSizes).join(", ")}.`);
+    return { error: `Invalid tip size. Please specify one of ${Object.keys(validTipSizes).join(", ")}.` };
   }
 
   return validTipSizes[tipSizeInput];
@@ -59,7 +59,7 @@ export function tipSizeToOpenGovTrack(tipRequest: TipRequest): { track: OpenGovT
   };
 }
 
-export function parseContributorAccount(bodys: (string | null)[]): ContributorAccount {
+export function parseContributorAccount(bodys: (string | null)[]): ContributorAccount | { error: string } {
   for (const body of bodys) {
     const matches =
       typeof body === "string" &&
@@ -81,17 +81,17 @@ export function parseContributorAccount(bodys: (string | null)[]): ContributorAc
         ? validNetworks[networkInput.toLowerCase() as keyof typeof validNetworks]
         : undefined;
     if (!network) {
-      throw new Error(
-        `Invalid network: "${networkInput}". Please select one of: ${Object.keys(validNetworks).join(", ")}.`,
-      );
+      return {
+        error: `Invalid network: "${networkInput}". Please select one of: ${Object.keys(validNetworks).join(", ")}.`,
+      };
     }
 
     return { network, address };
   }
 
-  throw new Error(
-    `Contributor did not properly post their account address.\n\nMake sure the pull request description (or user bio) has: "{network} address: {address}".`,
-  );
+  return {
+    error: `Contributor did not properly post their account address.\n\nMake sure the pull request description (or user bio) has: "{network} address: {address}".`,
+  };
 }
 
 /**


### PR DESCRIPTION
- There should be no behaviour change, only refactorings.
- Having previously removed the `"skip"` type of a result type, we can now change the result type to a simple boolean and change the `switch` statement into a simple `if-else`.
- Change the `handleTipRequest.then().catch()` construct into a `try-catch`, for a more top-to-bottom reading experience.