### PR TITLE
Update the way we calculate byte size of the proposals

### DIFF
--- a/src/tip.integration.ts
+++ b/src/tip.integration.ts
@@ -120,10 +120,11 @@ describe("tip", () => {
       test(`getReferendumId in ${network}`, async () => {
         const api = network === "localkusama" ? kusamaApi : polkadotApi;
         const tipRequest = getTipRequest({ size: new BN("1") }, network);
-        const encodedProposal = encodeProposal(api, tipRequest);
-        if (typeof encodedProposal !== "string") {
+        const encodeProposalResult = encodeProposal(api, tipRequest);
+        if ("success" in encodeProposalResult) {
           throw new Error("Encoding the proposal failed.");
         }
+        const { encodedProposal } = encodeProposalResult;
         const nextFreeReferendumId = new BN(await api.query.referenda.referendumCount());
 
         // We surround our tip with two "decoys" to make sure that we find the proper one.

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import { ApiPromise } from "@polkadot/api";
+import { SubmittableExtrinsic } from "@polkadot/api/promise/types";
 import type { ApiDecoration } from "@polkadot/api/types";
 import { BN } from "@polkadot/util";
 import assert from "assert";
@@ -142,8 +143,8 @@ export const formatTipSize = (tipRequest: TipRequest): string => {
 export const teamMatrixHandles =
   process.env.NODE_ENV === "development" ? [] : ["@przemek", "@mak", "@yuri", "@bullrich"]; // Don't interrupt other people when testing.
 
-// https://stackoverflow.com/a/52254083
-export const byteSize = (str: string): number => new Blob([str]).size;
+export const byteSize = (extrinsic: SubmittableExtrinsic): number =>
+  extrinsic.method.toU8a().length * Uint8Array.BYTES_PER_ELEMENT;
 
 export const encodeProposal = (api: ApiPromise, tipRequest: TipRequest): string | TipResult => {
   const track = tipSizeToOpenGovTrack(tipRequest);
@@ -154,7 +155,7 @@ export const encodeProposal = (api: ApiPromise, tipRequest: TipRequest): string 
 
   const proposalTx = api.tx.treasury.spend(track.value.toString(), contributorAddress);
   const encodedProposal = proposalTx.method.toHex();
-  const proposalByteSize = byteSize(encodedProposal);
+  const proposalByteSize = byteSize(proposalTx);
   if (proposalByteSize >= 128) {
     return {
       success: false,

--- a/src/util.ts
+++ b/src/util.ts
@@ -146,7 +146,10 @@ export const teamMatrixHandles =
 export const byteSize = (extrinsic: SubmittableExtrinsic): number =>
   extrinsic.method.toU8a().length * Uint8Array.BYTES_PER_ELEMENT;
 
-export const encodeProposal = (api: ApiPromise, tipRequest: TipRequest): string | TipResult => {
+export const encodeProposal = (
+  api: ApiPromise,
+  tipRequest: TipRequest,
+): { encodedProposal: string; proposalByteSize: number } | TipResult => {
   const track = tipSizeToOpenGovTrack(tipRequest);
   if ("error" in track) {
     return { success: false, errorMessage: track.error };
@@ -162,7 +165,7 @@ export const encodeProposal = (api: ApiPromise, tipRequest: TipRequest): string 
       errorMessage: `The proposal length of ${proposalByteSize} equals or exceeds 128 bytes and cannot be inlined in the referendum.`,
     };
   }
-  return encodedProposal;
+  return { encodedProposal, proposalByteSize };
 };
 
 /**


### PR DESCRIPTION
Previously we were calculating the byte size of strings, without taking into account that those are hexes.