### PR TITLE
Normalise DOT/KSM tip size purchasing power

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ In OpenGov, the tip sizes are translated to specific values as follows:
 
 Size | Value on Kusama | Value on Polkadot
 --- | --- | ---
-small | 2 KSM | 20 DOT
-medium | 5 KSM | 80 DOT
-large | 8 KSM | 150 DOT
+small | 4 KSM | 20 DOT
+medium | 16 KSM | 80 DOT
+large | 30 KSM | 150 DOT
 
 ## Local development 🔧
 

--- a/src/chain-config.ts
+++ b/src/chain-config.ts
@@ -1,7 +1,7 @@
 import { ChainConfig, TipNetwork } from "./types";
 
 type Constants = Omit<ChainConfig, "providerEndpoint">;
-const kusamaConstants: Constants = {
+export const kusamaConstants: Constants = {
   decimals: 12,
   currencySymbol: "KSM",
 
@@ -25,7 +25,7 @@ const kusamaConstants: Constants = {
   namedTips: { small: 4, medium: 16, large: 30 },
 };
 
-const polkadotConstants: Constants = {
+export const polkadotConstants: Constants = {
   decimals: 10,
   currencySymbol: "DOT",
 

--- a/src/chain-config.ts
+++ b/src/chain-config.ts
@@ -22,7 +22,7 @@ const kusamaConstants: Constants = {
   /**
    * These are arbitrary values, can be changed at any time.
    */
-  namedTips: { small: 2, medium: 5, large: 8 },
+  namedTips: { small: 4, medium: 16, large: 30 },
 };
 
 const polkadotConstants: Constants = {

--- a/src/tip-opengov.e2e.ts
+++ b/src/tip-opengov.e2e.ts
@@ -12,7 +12,7 @@ import { BN } from "@polkadot/util";
 import { cryptoWaitReady } from "@polkadot/util-crypto";
 import assert from "assert";
 
-import { getChainConfig } from "./chain-config";
+import { getChainConfig, kusamaConstants } from "./chain-config";
 import { randomAddress } from "./testUtil";
 import { tipUser } from "./tip";
 import { State, TipRequest } from "./types";
@@ -90,7 +90,8 @@ describe("E2E opengov tip", () => {
     // Waiting for the referendum voting, enactment, and treasury spend period.
     await until(async () => (await getUserBalance(tipRequest.contributor.account.address)).gtn(0), 5000, 50);
 
-    // At the end, the balance of the contributor should increase by 2 KSM.
-    expect((await getUserBalance(tipRequest.contributor.account.address)).eq(new BN("2000000000000"))).toBeTruthy();
+    // At the end, the balance of the contributor should increase by the KSM small tip amount.
+    const expectedTip = new BN(kusamaConstants.namedTips.small).mul(new BN("10").pow(new BN(kusamaConstants.decimals)));
+    expect((await getUserBalance(tipRequest.contributor.account.address)).eq(expectedTip)).toBeTruthy();
   });
 });


### PR DESCRIPTION
At current USD prices,
- a small KSM tip is $38.46 and a small DOT tip is $82.77
- a medium KSM tip is $95.3 and a medium DOT tip is $334.4
- a large KSM tip is $152.48 and a large DOT tip is $606

I don't think it makes sense for the purchasing power of the same 'size' tip to differ so drastically depending on the network being tipped on.

1 KSM is approximately 5 DOT at current prices, so I've updated the KSM tip sizes to be 1/5 of the DOT sizes. This is not perfect, but better than the current situation.