### PR TITLE
Add topic to edited post

### DIFF
--- a/src/polkassembly/polkassembly.ts
+++ b/src/polkassembly/polkassembly.ts
@@ -148,10 +148,15 @@ export class Polkassembly {
       this.log.error("Attempted to edit Polkassembly post without logging in.");
       throw new Error("Not logged in.");
     }
+    const body = {
+      ...opts,
+      // GENERAL from https://github.com/polkassembly/polkassembly/blob/670f3ab9dae95ccb9a293f8cadfa409620604abf/src/global/post_topics.ts
+      topicId: 5,
+    };
     const response = await fetch(`${this.endpoint}/auth/actions/editPost`, {
       headers: { ...headers, "x-network": network, authorization: `Bearer ${this.token}` },
       method: "POST",
-      body: JSON.stringify(opts),
+      body: JSON.stringify(body),
     });
     if (!response.ok) {
       this.log.error(`editPost failed with status code ${response.status}`);


### PR DESCRIPTION
As of [this change](https://github.com/polkassembly/polkassembly/pull/1111), a `topicId` has become a necessary parameters of editing a post.

I'm not sure which topic to choose - selected `general` without strong opinion.

This fixes https://github.com/paritytech/substrate-tip-bot/issues/132

Tested on Moonbase alpha: https://moonbase.polkassembly.network/referenda/61

---

<img width="420px" src="https://github.com/paritytech/substrate-tip-bot/assets/12039224/06b29075-9bbd-4734-9daf-c8d2f88377be"/>

