### PR TITLE
Keep Polkadot cache warm

### DIFF
--- a/.github/workflows/keep-polkadot-cache.yml
+++ b/.github/workflows/keep-polkadot-cache.yml
@@ -1,0 +1,24 @@
+name: Keep Polkadot cache
+on:
+  schedule:
+    - cron: 0 3 */6 * * # Every 6 days at 3 am.
+  push:
+
+jobs:
+  keep-polkadot-cache:
+    timeout-minutes: 15
+    runs-on: ubuntu-22.04
+    container: paritytech/ci-linux:production
+    env:
+      POLKADOT_VERSION: 'v0.9.42'
+
+    steps:
+      - uses: actions/checkout@v3.3.0
+        with:
+          path: substrate-tip-bot
+      - name: Restore cached Polkadot build
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            polkadot/target/release
+          key: ${{ runner.os }}-${{ env.POLKADOT_VERSION }}-${{ hashFiles('substrate-tip-bot/polkadot.e2e.patch') }}

--- a/.github/workflows/keep-polkadot-cache.yml
+++ b/.github/workflows/keep-polkadot-cache.yml
@@ -2,7 +2,10 @@ name: Keep Polkadot cache
 on:
   schedule:
     - cron: 0 3 */6 * * # Every 6 days at 3 am.
-  push:
+
+# The Github Actions cache is removed if not used for 7 days.
+# In this repository, we have a Polkadot build cache that takes a long time to build.
+# This workflow will restore the cache every 6 days, in order to preserve it.
 
 jobs:
   keep-polkadot-cache:

--- a/.github/workflows/keep-polkadot-cache.yml
+++ b/.github/workflows/keep-polkadot-cache.yml
@@ -8,7 +8,6 @@ jobs:
   keep-polkadot-cache:
     timeout-minutes: 15
     runs-on: ubuntu-22.04
-    container: paritytech/ci-linux:production
     env:
       POLKADOT_VERSION: 'v0.9.42'
 


### PR DESCRIPTION
This repo has infrequent PR, which cause the Polkadot build cache to expire (after 7 days).

The build cache takes a long time to build, so it is worth to go the extra step to preserve it.

This workflow will download the cache every 6 days, in order to keep it warm and preserve it from being removed automatically by Github.