### PR TITLE
ci: fix argocd-deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -147,6 +147,8 @@ publish-docker-image-description:
   variables:
     ARGOCD_OPTS: --grpc-web --grpc-web-root-path /$ENVIRONMENT
     APP: substrate-tip-bot
+  environment:
+    name: $ENVIRONMENT
   script:
     - argocd app list
     - argocd app set $APP --helm-set common.image.tag="${DOCKER_TAG}"


### PR DESCRIPTION
Fix for https://github.com/paritytech/substrate-tip-bot/pull/139 ([CI Job](https://gitlab.parity.io/parity/mirrors/substrate-tip-bot/-/jobs/5139204))

argocd token only available if environment is set. 