### PR TITLE
Update treasury extrinsic

### DIFF
--- a/.github/workflows/keep-polkadot-cache.yml
+++ b/.github/workflows/keep-polkadot-cache.yml
@@ -22,5 +22,5 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: |
-            polkadot/target/release
+            polkadot-sdk/target/release
           key: ${{ runner.os }}-${{ env.POLKADOT_VERSION }}-${{ hashFiles('substrate-tip-bot/polkadot.e2e.patch') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Build Polkadot
         if: steps.polkadot-cache-restore.outputs.cache-hit != 'true'
         run: |
-          ./scripts/init.sh
           cargo build --release --locked --features=fast-runtime -p polkadot
         working-directory: polkadot-sdk
       - name: Save Polkadot build cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Build Polkadot
         if: steps.polkadot-cache-restore.outputs.cache-hit != 'true'
         run: |
+          rustup update nightly
+          rustup update stable
+          rustup target add wasm32-unknown-unknown --toolchain nightly
           cargo build --release --locked --features=fast-runtime -p polkadot
         working-directory: polkadot-sdk
       - name: Save Polkadot build cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     container: paritytech/ci-linux:production
     env:
-      POLKADOT_VERSION: 'v0.9.42'
+      POLKADOT_VERSION: 'polkadot-v1.7.1'
 
     steps:
       - uses: actions/checkout@v3.3.0
@@ -34,35 +34,35 @@ jobs:
         working-directory: substrate-tip-bot
       - uses: actions/checkout@v3.3.0
         with:
-          repository: paritytech/polkadot
+          repository: paritytech/polkadot-sdk
           ref: ${{ env.POLKADOT_VERSION }}
-          path: polkadot
+          path: polkadot-sdk
       - name: Apply Polkadot patches
         run: git apply ../substrate-tip-bot/polkadot.e2e.patch
-        working-directory: polkadot
+        working-directory: polkadot-sdk
       - name: Restore cached Polkadot build
         id: polkadot-cache-restore
         uses: actions/cache/restore@v3
         with:
           path: |
-            polkadot/target/release
+            polkadot-sdk/target/release
           key: ${{ runner.os }}-${{ env.POLKADOT_VERSION }}-${{ hashFiles('substrate-tip-bot/polkadot.e2e.patch') }}
       - name: Build Polkadot
         if: steps.polkadot-cache-restore.outputs.cache-hit != 'true'
         run: |
           ./scripts/init.sh
           cargo build --release --locked --features=fast-runtime -p polkadot
-        working-directory: polkadot
+        working-directory: polkadot-sdk
       - name: Save Polkadot build cache
         uses: actions/cache/save@v3
         with:
           path: |
-            polkadot/target/release
+            polkadot-sdk/target/release
           key: ${{ runner.os }}-${{ env.POLKADOT_VERSION }}-${{ hashFiles('substrate-tip-bot/polkadot.e2e.patch') }}
-      - name: Run a local Kusama node
+      - name: Run a local Rococo node
         run: |
-          polkadot/target/release/polkadot --ws-external --rpc-external --no-prometheus --no-telemetry --chain=kusama-dev --tmp --alice --execution Native --ws-port 9901 --force-kusama &
-          until curl -s '127.0.0.1:9901'; do sleep 3; done
+          polkadot-sdk/target/release/polkadot --rpc-external --no-prometheus --no-telemetry --chain=rococo-dev --tmp --alice --execution Native --rpc-port 9902 &
+          until curl -s '127.0.0.1:9902'; do sleep 3; done
         timeout-minutes: 1
       - name: Run the tests
         run: yarn test:e2e

--- a/README.md
+++ b/README.md
@@ -128,18 +128,20 @@ $ docker run \
 
 ## End-to-end tests
 
-For the E2E tests, we need a modified Kusama node in a way that speeds up the referenda and treasury.
+For the E2E tests, we need a modified Rococo node in a way that speeds up the referenda and treasury.
 
-### Preparing and running Kusama
+### Preparing and running Rococo
 
 ```bash
-git clone https://github.com/paritytech/polkadot.git
-cd polkadot
-git checkout v0.9.42
+git clone https://github.com/paritytech/polkadot-sdk.git
+cd polkadot-sdk
+git checkout polkadot-v1.7.1
 git apply ../polkadot.e2e.patch
 cargo build --release --locked --features=fast-runtime -p polkadot
-./target/release/polkadot --ws-external --rpc-external --no-prometheus --no-telemetry --chain=kusama-dev --tmp --alice --execution Native --ws-port 9901 --force-kusama
+./target/release/polkadot --rpc-external --no-prometheus --no-telemetry --chain=rococo-dev --tmp --alice --execution Native --rpc-port 9902
 ```
+
+You might need to fund the treasury (`13UVJyLnbVp9RBZYFwFGyDvVd1y27Tt8tkntv6Q7JVPhFsTB`) if it is broke.
 
 ### Running the E2E tests
 

--- a/polkadot.e2e.patch
+++ b/polkadot.e2e.patch
@@ -1,7 +1,7 @@
-diff --git a/runtime/kusama/src/governance/mod.rs b/runtime/kusama/src/governance/mod.rs
-index c8a7b360ed..78bd7fbe67 100644
---- a/runtime/kusama/src/governance/mod.rs
-+++ b/runtime/kusama/src/governance/mod.rs
+diff --git a/polkadot/runtime/rococo/src/governance/mod.rs b/polkadot/runtime/rococo/src/governance/mod.rs
+index ef2adf60753..218c0a3c837 100644
+--- a/polkadot/runtime/rococo/src/governance/mod.rs
++++ b/polkadot/runtime/rococo/src/governance/mod.rs
 @@ -35,7 +35,7 @@ mod fellowship;
  pub use fellowship::{FellowshipCollectiveInstance, FellowshipReferendaInstance};
  
@@ -11,26 +11,45 @@ index c8a7b360ed..78bd7fbe67 100644
  }
  
  impl pallet_conviction_voting::Config for Runtime {
-diff --git a/runtime/kusama/src/governance/tracks.rs b/runtime/kusama/src/governance/tracks.rs
-index 08a87a677c..2f556e9602 100644
---- a/runtime/kusama/src/governance/tracks.rs
-+++ b/runtime/kusama/src/governance/tracks.rs
-@@ -213,8 +213,8 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15
+diff --git a/polkadot/runtime/rococo/src/governance/tracks.rs b/polkadot/runtime/rococo/src/governance/tracks.rs
+index 3765569f183..ed226f4ef65 100644
+--- a/polkadot/runtime/rococo/src/governance/tracks.rs
++++ b/polkadot/runtime/rococo/src/governance/tracks.rs
+@@ -212,10 +212,10 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15
+ 			name: "small_tipper",
  			max_deciding: 200,
- 			decision_deposit: 1 * QUID,
- 			prepare_period: 1 * MINUTES,
--			decision_period: 7 * DAYS,
--			confirm_period: 10 * MINUTES,
+ 			decision_deposit: 1 * 3 * CENTS,
+-			prepare_period: 1 * MINUTES,
+-			decision_period: 14 * MINUTES,
+-			confirm_period: 4 * MINUTES,
+-			min_enactment_period: 1 * MINUTES,
++			prepare_period: 1,
 +			decision_period: 1,
 +			confirm_period: 1,
- 			min_enactment_period: 1 * MINUTES,
++			min_enactment_period: 1,
  			min_approval: APP_SMALL_TIPPER,
  			min_support: SUP_SMALL_TIPPER,
-diff --git a/runtime/kusama/src/lib.rs b/runtime/kusama/src/lib.rs
-index 35dc79a4b5..07acab5014 100644
---- a/runtime/kusama/src/lib.rs
-+++ b/runtime/kusama/src/lib.rs
-@@ -606,7 +606,7 @@ parameter_types! {
+ 		},
+@@ -226,10 +226,10 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15
+ 			name: "big_tipper",
+ 			max_deciding: 100,
+ 			decision_deposit: 10 * 3 * CENTS,
+-			prepare_period: 4 * MINUTES,
+-			decision_period: 14 * MINUTES,
+-			confirm_period: 12 * MINUTES,
+-			min_enactment_period: 3 * MINUTES,
++			prepare_period: 1,
++			decision_period: 1,
++			confirm_period: 1,
++			min_enactment_period: 1,
+ 			min_approval: APP_BIG_TIPPER,
+ 			min_support: SUP_BIG_TIPPER,
+ 		},
+diff --git a/polkadot/runtime/rococo/src/lib.rs b/polkadot/runtime/rococo/src/lib.rs
+index 03e96ab388b..f4a58d1792c 100644
+--- a/polkadot/runtime/rococo/src/lib.rs
++++ b/polkadot/runtime/rococo/src/lib.rs
+@@ -451,7 +451,7 @@ parameter_types! {
  	pub const ProposalBond: Permill = Permill::from_percent(5);
  	pub const ProposalBondMinimum: Balance = 2000 * CENTS;
  	pub const ProposalBondMaximum: Balance = 1 * GRAND;
@@ -38,4 +57,64 @@ index 35dc79a4b5..07acab5014 100644
 +	pub const SpendPeriod: BlockNumber = 1;
  	pub const Burn: Permill = Permill::from_perthousand(2);
  	pub const TreasuryPalletId: PalletId = PalletId(*b"py/trsry");
+ 	pub const PayoutSpendPeriod: BlockNumber = 30 * DAYS;
+diff --git a/polkadot/runtime/westend/src/governance/mod.rs b/polkadot/runtime/westend/src/governance/mod.rs
+index d027f788d71..de6f36ecfce 100644
+--- a/polkadot/runtime/westend/src/governance/mod.rs
++++ b/polkadot/runtime/westend/src/governance/mod.rs
+@@ -32,7 +32,7 @@ mod tracks;
+ pub use tracks::TracksInfo;
  
+ parameter_types! {
+-	pub const VoteLockingPeriod: BlockNumber = 7 * DAYS;
++	pub const VoteLockingPeriod: BlockNumber = 1;
+ }
+ 
+ impl pallet_conviction_voting::Config for Runtime {
+diff --git a/polkadot/runtime/westend/src/governance/tracks.rs b/polkadot/runtime/westend/src/governance/tracks.rs
+index 3765569f183..ed226f4ef65 100644
+--- a/polkadot/runtime/westend/src/governance/tracks.rs
++++ b/polkadot/runtime/westend/src/governance/tracks.rs
+@@ -212,10 +212,10 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15
+ 			name: "small_tipper",
+ 			max_deciding: 200,
+ 			decision_deposit: 1 * 3 * CENTS,
+-			prepare_period: 1 * MINUTES,
+-			decision_period: 14 * MINUTES,
+-			confirm_period: 4 * MINUTES,
+-			min_enactment_period: 1 * MINUTES,
++			prepare_period: 1,
++			decision_period: 1,
++			confirm_period: 1,
++			min_enactment_period: 1,
+ 			min_approval: APP_SMALL_TIPPER,
+ 			min_support: SUP_SMALL_TIPPER,
+ 		},
+@@ -226,10 +226,10 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15
+ 			name: "big_tipper",
+ 			max_deciding: 100,
+ 			decision_deposit: 10 * 3 * CENTS,
+-			prepare_period: 4 * MINUTES,
+-			decision_period: 14 * MINUTES,
+-			confirm_period: 12 * MINUTES,
+-			min_enactment_period: 3 * MINUTES,
++			prepare_period: 1,
++			decision_period: 1,
++			confirm_period: 1,
++			min_enactment_period: 1,
+ 			min_approval: APP_BIG_TIPPER,
+ 			min_support: SUP_BIG_TIPPER,
+ 		},
+diff --git a/polkadot/runtime/westend/src/lib.rs b/polkadot/runtime/westend/src/lib.rs
+index bbb010f60bf..ab0a6569482 100644
+--- a/polkadot/runtime/westend/src/lib.rs
++++ b/polkadot/runtime/westend/src/lib.rs
+@@ -711,7 +711,7 @@ parameter_types! {
+ 	pub const ProposalBond: Permill = Permill::from_percent(5);
+ 	pub const ProposalBondMinimum: Balance = 2000 * CENTS;
+ 	pub const ProposalBondMaximum: Balance = 1 * GRAND;
+-	pub const SpendPeriod: BlockNumber = 6 * DAYS;
++	pub const SpendPeriod: BlockNumber = 1;
+ 	pub const Burn: Permill = Permill::from_perthousand(2);
+ 	pub const TreasuryPalletId: PalletId = PalletId(*b"py/trsry");
+ 	pub const PayoutSpendPeriod: BlockNumber = 30 * DAYS;

--- a/src/tip-opengov.e2e.ts
+++ b/src/tip-opengov.e2e.ts
@@ -69,7 +69,9 @@ describe("E2E opengov tip", () => {
     alice = keyring.addFromUri("//Alice");
 
     // In some local dev chains, treasury is broke, so we fund it.
-    await api.tx.balances.transferKeepAlive(treasuryAccount, new BN("10000000000000")).signAndSend(alice, { nonce: -1 });
+    await api.tx.balances
+      .transferKeepAlive(treasuryAccount, new BN("10000000000000"))
+      .signAndSend(alice, { nonce: -1 });
   });
 
   test("Small OpenGov tip", async () => {

--- a/src/tip-opengov.e2e.ts
+++ b/src/tip-opengov.e2e.ts
@@ -12,7 +12,7 @@ import { BN } from "@polkadot/util";
 import { cryptoWaitReady } from "@polkadot/util-crypto";
 import assert from "assert";
 
-import { getChainConfig, kusamaConstants } from "./chain-config";
+import { getChainConfig, rococoConstants } from "./chain-config";
 import { randomAddress } from "./testUtil";
 import { tipUser } from "./tip";
 import { State, TipRequest } from "./types";
@@ -21,25 +21,28 @@ const logMock: any = console.log.bind(console); // eslint-disable-line @typescri
 logMock.error = console.error.bind(console);
 
 const tipperAccount = "14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3"; // Bob
+const treasuryAccount = "13UVJyLnbVp9RBZYFwFGyDvVd1y27Tt8tkntv6Q7JVPhFsTB"; // https://wiki.polkadot.network/docs/learn-account-advanced#system-accounts
+
+const network = "localrococo";
 
 describe("E2E opengov tip", () => {
   let state: State;
-  let kusamaApi: ApiPromise;
+  let api: ApiPromise;
   let alice: KeyringPair;
 
   beforeAll(() => {
-    kusamaApi = new ApiPromise({
-      provider: new WsProvider(getChainConfig("localkusama").providerEndpoint),
+    api = new ApiPromise({
+      provider: new WsProvider(getChainConfig(network).providerEndpoint),
       types: { Address: "AccountId", LookupSource: "AccountId" },
     });
   });
 
   afterAll(async () => {
-    await kusamaApi.disconnect();
+    await api.disconnect();
   });
 
   const getUserBalance = async (userAddress: string) => {
-    const { data } = await kusamaApi.query.system.account(userAddress);
+    const { data } = await api.query.system.account(userAddress);
     return data.free.toBn();
   };
 
@@ -47,11 +50,11 @@ describe("E2E opengov tip", () => {
     await cryptoWaitReady();
     const keyring = new Keyring({ type: "sr25519" });
     try {
-      await kusamaApi.isReadyOrError;
+      await api.isReadyOrError;
     } catch (e) {
       console.log(
-        `For these integrations tests, we're expecting local Kusama on ${
-          getChainConfig("localkusama").providerEndpoint
+        `For these integrations tests, we're expecting local Rococo on ${
+          getChainConfig(network).providerEndpoint
         }. Please refer to the Readme.`,
       );
     }
@@ -64,13 +67,16 @@ describe("E2E opengov tip", () => {
       bot: { log: logMock } as any, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
     };
     alice = keyring.addFromUri("//Alice");
+
+    // In some local dev chains, treasury is broke, so we fund it.
+    await api.tx.balances.transfer(treasuryAccount, new BN("10000000000000")).signAndSend(alice, { nonce: -1 });
   });
 
   test("Small OpenGov tip", async () => {
-    const referendumId = await kusamaApi.query.referenda.referendumCount(); // The next free referendum index.
+    const referendumId = await api.query.referenda.referendumCount(); // The next free referendum index.
     const tipRequest: TipRequest = {
       tip: { size: "small" },
-      contributor: { githubUsername: "test", account: { address: randomAddress(), network: "localkusama" } },
+      contributor: { githubUsername: "test", account: { address: randomAddress(), network } },
       pullRequestRepo: "test",
       pullRequestNumber: 1,
     };
@@ -82,8 +88,8 @@ describe("E2E opengov tip", () => {
     expect(result.success).toBeTruthy();
 
     // Alice votes "aye" on the referendum.
-    await kusamaApi.tx.referenda.placeDecisionDeposit(referendumId).signAndSend(alice, { nonce: -1 });
-    await kusamaApi.tx.convictionVoting
+    await api.tx.referenda.placeDecisionDeposit(referendumId).signAndSend(alice, { nonce: -1 });
+    await api.tx.convictionVoting
       .vote(referendumId, { Standard: { balance: new BN(1_000_000), vote: { aye: true, conviction: 1 } } })
       .signAndSend(alice, { nonce: -1 });
 
@@ -91,7 +97,7 @@ describe("E2E opengov tip", () => {
     await until(async () => (await getUserBalance(tipRequest.contributor.account.address)).gtn(0), 5000, 50);
 
     // At the end, the balance of the contributor should increase by the KSM small tip amount.
-    const expectedTip = new BN(kusamaConstants.namedTips.small).mul(new BN("10").pow(new BN(kusamaConstants.decimals)));
+    const expectedTip = new BN(rococoConstants.namedTips.small).mul(new BN("10").pow(new BN(rococoConstants.decimals)));
     expect((await getUserBalance(tipRequest.contributor.account.address)).eq(expectedTip)).toBeTruthy();
   });
 });

--- a/src/tip-opengov.e2e.ts
+++ b/src/tip-opengov.e2e.ts
@@ -69,7 +69,7 @@ describe("E2E opengov tip", () => {
     alice = keyring.addFromUri("//Alice");
 
     // In some local dev chains, treasury is broke, so we fund it.
-    await api.tx.balances.transfer(treasuryAccount, new BN("10000000000000")).signAndSend(alice, { nonce: -1 });
+    await api.tx.balances.transferKeepAlive(treasuryAccount, new BN("10000000000000")).signAndSend(alice, { nonce: -1 });
   });
 
   test("Small OpenGov tip", async () => {

--- a/src/tip.integration.ts
+++ b/src/tip.integration.ts
@@ -30,7 +30,7 @@ const getTipRequest = (tip: TipRequest["tip"], network: "localrococo" | "localwe
   };
 };
 
-const POLKADOT_VERSION = 'v1.7.1'
+const POLKADOT_VERSION = "v1.7.1";
 const networks = ["localrococo", "localwestend"] as const;
 const tipSizes: TipRequest["tip"]["size"][] = ["small", "medium", "large", new BN("1"), new BN("3")];
 const commonDockerArgs =

--- a/src/util.ts
+++ b/src/util.ts
@@ -164,7 +164,7 @@ export const encodeProposal = (
   }
   const contributorAddress = tipRequest.contributor.account.address;
 
-  const proposalTx = api.tx.treasury.spend(track.value.toString(), contributorAddress);
+  const proposalTx = api.tx.treasury.spendLocal(track.value.toString(), contributorAddress);
   const encodedProposal = proposalTx.method.toHex();
   const proposalByteSize = byteSize(proposalTx);
   if (proposalByteSize >= 128) {


### PR DESCRIPTION
An update after this change: https://github.com/paritytech/polkadot-sdk/pull/1333

- Update Polkadot version in E2E and integration tests to `v1.7.1`.
- Use Rococo and Westend instead of Polkadot and Kusama local dev chains (since they have been moved out).
- In E2E tests, fund the treasury - it is now empty when you start a dev chain.