### PR TITLE
Use version sort when determining the latest Polkadot release

### DIFF
--- a/.github/workflows/test-e2e-cron.yml
+++ b/.github/workflows/test-e2e-cron.yml
@@ -16,7 +16,7 @@ jobs:
           # Fetch all Polkadot release tags, get the last (newest) one, and parse its name from the output.
           TAG=$(git ls-remote --refs --tags https://github.com/paritytech/polkadot-sdk.git 'polkadot-v*' \
             | sed 's,[^r]*refs/tags/,,' \
-            | sort --version-sort
+            | sort --version-sort \
             | tail -1)
             echo "tag=$TAG" >> $GITHUB_OUTPUT
       - name: Announce version

--- a/.github/workflows/test-e2e-cron.yml
+++ b/.github/workflows/test-e2e-cron.yml
@@ -15,8 +15,9 @@ jobs:
         run: |
           # Fetch all Polkadot release tags, get the last (newest) one, and parse its name from the output.
           TAG=$(git ls-remote --refs --tags https://github.com/paritytech/polkadot-sdk.git 'polkadot-v*' \
-            | tail -1 \
-            | sed 's,[^r]*refs/tags/,,')
+            | sed 's,[^r]*refs/tags/,,' \
+            | sort --version-sort
+            | tail -1)
             echo "tag=$TAG" >> $GITHUB_OUTPUT
       - name: Announce version
         run: echo "Running tests with Polkadot version ${{ steps.read-tag.outputs.tag }}"


### PR DESCRIPTION
Currently, it was taking 1.9.0 as the last one from:

```
polkadot-v1.1.0
polkadot-v1.10.0
polkadot-v1.11.0
polkadot-v1.12.0
polkadot-v1.2.0
polkadot-v1.3.0
polkadot-v1.4.0
polkadot-v1.5.0
polkadot-v1.5.0-nix
polkadot-v1.6.0
polkadot-v1.7.0
polkadot-v1.7.1
polkadot-v1.7.2
polkadot-v1.8.0
polkadot-v1.9.0
```