### PR TITLE
Specify node version to omit `2.5.0`

### DIFF
--- a/.github/workflows/test-e2e-cron.yml
+++ b/.github/workflows/test-e2e-cron.yml
@@ -32,7 +32,7 @@ jobs:
         timeout-minutes: 1
       - uses: actions/setup-node@v3.5.1
         with:
-          node-version: "22.4"
+          node-version: "22.5.1"
       - run: yarn --immutable
       - run: yarn test:e2e
         timeout-minutes: 10

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -22,7 +22,7 @@ jobs:
         timeout-minutes: 1
       - uses: actions/setup-node@v3.5.1
         with:
-          node-version: "22.4"
+          node-version: "22.5.1"
       - run: yarn --immutable
       - run: yarn test:e2e
         timeout-minutes: 10

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3.5.1
         with:
-          node-version: 22.4
+          node-version: 22.5.1
       - run: yarn --immutable
       - run: yarn test:integration --verbose

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.4-alpine as builder
+FROM node:22.5.1-alpine as builder
 
 WORKDIR /usr/src/app
 
@@ -10,7 +10,7 @@ COPY src/ ./src
 
 RUN yarn build
 
-FROM node:22.4-slim
+FROM node:22.5.1-slim
 
 # metadata
 ARG VCS_REF=master

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typescript": "^5.4.5"
   },
   "engines": {
-    "node": "^22 && < 22.5"
+    "node": "^22 && !22.5.0"
   },
   "packageManager": "yarn@4.3.0"
 }


### PR DESCRIPTION
Because of https://github.com/yarnpkg/berry/issues/6398

There was a fix in `2.5.1`: https://github.com/yarnpkg/berry/issues/6398#issuecomment-2239327003