### PR TITLE
Use `polkadot-stable*` tags for cron-bases E2E tests

### DIFF
--- a/.github/workflows/test-e2e-cron.yml
+++ b/.github/workflows/test-e2e-cron.yml
@@ -14,7 +14,7 @@ jobs:
         id: read-tag
         run: |
           # Fetch all Polkadot release tags, get the last (newest) one, and parse its name from the output.
-          TAG=$(git ls-remote --refs --tags https://github.com/paritytech/polkadot-sdk.git 'polkadot-v*' \
+          TAG=$(git ls-remote --refs --tags https://github.com/paritytech/polkadot-sdk.git 'polkadot-stable*' \
             | sed 's,[^r]*refs/tags/,,' \
             | sort --version-sort \
             | tail -1)

--- a/.github/workflows/test-e2e-cron.yml
+++ b/.github/workflows/test-e2e-cron.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     - cron: 0 3 * * SUN # Once a week on Sunday.
   workflow_dispatch:
+  push:
 
 jobs:
   test-e2e-cron:

--- a/.github/workflows/test-e2e-cron.yml
+++ b/.github/workflows/test-e2e-cron.yml
@@ -3,7 +3,6 @@ on:
   schedule:
     - cron: 0 3 * * SUN # Once a week on Sunday.
   workflow_dispatch:
-  push:
 
 jobs:
   test-e2e-cron:


### PR DESCRIPTION
The `polkadot-v*` tags are still there, but they will go away so we might as well change it now.