### PR TITLE
Don't use prerelase versions for E2E tests

### DIFF
--- a/.github/workflows/test-e2e-cron.yml
+++ b/.github/workflows/test-e2e-cron.yml
@@ -17,7 +17,7 @@ jobs:
           # Fetch all Polkadot release tags, get the last (newest) one, and parse its name from the output.
           TAG=$(git ls-remote --refs --tags https://github.com/paritytech/polkadot-sdk.git 'polkadot-stable*' \
             | sed 's,[^r]*refs/tags/,,' \
-            | grep -v '\-rc*'
+            | grep -v '\-rc*' \
             | sort --version-sort \
             | tail -1)
             echo "tag=$TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-e2e-cron.yml
+++ b/.github/workflows/test-e2e-cron.yml
@@ -16,6 +16,7 @@ jobs:
           # Fetch all Polkadot release tags, get the last (newest) one, and parse its name from the output.
           TAG=$(git ls-remote --refs --tags https://github.com/paritytech/polkadot-sdk.git 'polkadot-stable*' \
             | sed 's,[^r]*refs/tags/,,' \
+            | grep -v '\-rc*'
             | sort --version-sort \
             | tail -1)
             echo "tag=$TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-e2e-cron.yml
+++ b/.github/workflows/test-e2e-cron.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     - cron: 0 3 * * SUN # Once a week on Sunday.
   workflow_dispatch:
+  push:
 
 jobs:
   test-e2e-cron:

--- a/.github/workflows/test-e2e-cron.yml
+++ b/.github/workflows/test-e2e-cron.yml
@@ -3,7 +3,6 @@ on:
   schedule:
     - cron: 0 3 * * SUN # Once a week on Sunday.
   workflow_dispatch:
-  push:
 
 jobs:
   test-e2e-cron:


### PR DESCRIPTION
We better use the most recent, but stable release for out tests - there is no need to test prerelease here.