### PR TITLE
Using correct tokens for multi org setup

### DIFF
--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -1,4 +1,9 @@
 const commonConfig = require("./jest.config.js");
 
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-module.exports = { ...commonConfig, testMatch: ["**/?(*.)+(integration).[jt]s?(x)"], testTimeout: 2 * 60_000 };
+/** @type {import("ts-jest/dist/types").InitialOptionsTsJest} */
+module.exports = {
+  ...commonConfig,
+  testMatch: ["**/?(*.)+(integration).[jt]s?(x)"],
+  testTimeout: 2 * 60_000,
+  silent: false,
+};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "start": "node --env-file=.env --enable-source-maps dist/src/bot.js",
     "test": "jest",
     "test:e2e": "jest -c jest.e2e.config.js",
-    "test:integration": "jest -c jest.integration.config.js",
+    "test:integration": "jest --runInBand -c jest.integration.config.js",
     "typecheck": "tsc --noEmit"
   },
   "imports": {
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@eng-automation/js-style": "^3.1.0",
-    "@eng-automation/testing": "^1.5.0",
+    "@eng-automation/testing": "^1.5.2",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.2",
     "dotenv": "^16.0.1",

--- a/src/tip.integration.ts
+++ b/src/tip.integration.ts
@@ -38,7 +38,7 @@ function logConsumer(name: string, addTs: boolean = true): (stream: Readable) =>
   };
 }
 
-const POLKADOT_VERSION = "v1.15.0";
+const POLKADOT_VERSION = "v1.15.2";
 const networks = ["rococo", "westend"] as const;
 const tipSizes = ["small", "medium", "large", "1", "3"];
 const commonDockerArgs =
@@ -46,6 +46,9 @@ const commonDockerArgs =
 const probotPort = 3000; // default value; not configured in the app
 
 export const jsonResponseHeaders = { "content-type": "application/json" };
+
+const tipBotOrgToken = "ghs_989898989898989898989898989898dfdfdfd";
+const paritytechStgOrgToken = "ghs_12345678912345678123456723456abababa";
 
 describe("tip", () => {
   let appContainer: StartedTestContainer;
@@ -64,28 +67,34 @@ describe("tip", () => {
   };
 
   const expectTipperMembership = async () => {
-    await gitHub.forGet("/orgs/tip-bot-org/teams/tip-bot-approvers/memberships/tipper").thenReply(
-      200,
-      JSON.stringify(
-        fixtures.github.getOrgMembershipPayload({
-          login: "tipper",
-          org: "tip-bot-approvers",
-        }),
-      ),
-      jsonResponseHeaders,
-    );
+    await gitHub
+      .forGet("/orgs/tip-bot-org/teams/tip-bot-approvers/memberships/tipper")
+      .withHeaders({ Authorization: `token ${tipBotOrgToken}` })
+      .thenReply(
+        200,
+        JSON.stringify(
+          fixtures.github.getOrgMembershipPayload({
+            login: "tipper",
+            org: "tip-bot-approvers",
+          }),
+        ),
+        jsonResponseHeaders,
+      );
   };
 
   const expectNoTipperMembership = async () => {
-    await gitHub.forGet("/orgs/tip-bot-org/teams/tip-bot-approvers/memberships/tipper").thenReply(
-      404,
-      JSON.stringify({
-        message: "Not Found",
-        documentation_url: "https://docs.github.com/rest/teams/members#get-team-membership-for-a-user",
-        status: "404",
-      }),
-      jsonResponseHeaders,
-    );
+    await gitHub
+      .forGet("/orgs/tip-bot-org/teams/tip-bot-approvers/memberships/tipper")
+      .withHeaders({ Authorization: `token ${tipBotOrgToken}` })
+      .thenReply(
+        404,
+        JSON.stringify({
+          message: "Not Found",
+          documentation_url: "https://docs.github.com/rest/teams/members#get-team-membership-for-a-user",
+          status: "404",
+        }),
+        jsonResponseHeaders,
+      );
   };
 
   beforeAll(async () => {
@@ -199,33 +208,56 @@ describe("tip", () => {
     assert(Number(await getUserBalance(rococoApi, tipperAccount)) > 0);
     assert(Number(await getUserBalance(westendApi, tipperAccount)) > 0);
 
-    await gitHub.forGet("/repos/paritytech-stg/testre/installation").thenReply(
-      200,
-      JSON.stringify(
-        fixtures.github.getAppInstallationsPayload([
-          {
-            accountLogin: "paritytech-stg",
-            accountId: 74720417,
-            id: 155,
-          },
-        ])[0],
-      ),
-      jsonResponseHeaders,
-    );
+    const appInstallations = fixtures.github.getAppInstallationsPayload([
+      {
+        accountLogin: "paritytech-stg",
+        accountId: 74720417,
+        id: 155,
+      },
+      {
+        accountLogin: "tip-bot-org",
+        accountId: 87878787,
+        id: 199,
+      },
+    ]);
 
-    await gitHub.forPost("/repos/paritytech-stg/testre/issues/comments/1234532076/reactions").thenReply(
-      200,
-      JSON.stringify(
-        fixtures.github.getIssueCommentReactionPayload({
-          content: "eyes",
-        }),
-      ),
-      jsonResponseHeaders,
-    );
+    await gitHub
+      .forGet("/repos/paritytech-stg/testre/installation")
+      .thenReply(200, JSON.stringify(appInstallations[0]), jsonResponseHeaders);
+
+    await gitHub
+      .forPost("/repos/paritytech-stg/testre/issues/comments/1234532076/reactions")
+      .withHeaders({ Authorization: `token ${paritytechStgOrgToken}` })
+      .thenReply(
+        200,
+        JSON.stringify(
+          fixtures.github.getIssueCommentReactionPayload({
+            content: "eyes",
+          }),
+        ),
+        jsonResponseHeaders,
+      );
 
     await gitHub
       .forPost("/app/installations/155/access_tokens")
-      .thenReply(200, JSON.stringify(fixtures.github.getAppInstallationTokenPayload()), jsonResponseHeaders);
+      .thenReply(
+        200,
+        JSON.stringify(fixtures.github.getAppInstallationTokenPayload(paritytechStgOrgToken)),
+        jsonResponseHeaders,
+      );
+
+    await gitHub
+      .forPost("/app/installations/199/access_tokens")
+      .thenReply(
+        200,
+        JSON.stringify(fixtures.github.getAppInstallationTokenPayload(tipBotOrgToken)),
+        jsonResponseHeaders,
+      );
+
+    await gitHub
+      .forGet("/app/installations")
+      .withQuery({ per_page: "100" })
+      .thenReply(200, JSON.stringify(appInstallations), jsonResponseHeaders);
   });
 
   afterAll(async () => {
@@ -252,24 +284,29 @@ describe("tip", () => {
 
     test.each(tipSizes)("tips a user (%s)", async (tipSize) => {
       await expectTipperMembership();
+
       const api = network === "rococo" ? rococoApi : westendApi;
       const nextFreeReferendumId = await api.query.Referenda.ReferendumCount.getValue();
-      await tipUser(appPort, tipSize);
 
-      const successEndpoint = await gitHub.forPost("/repos/paritytech-stg/testre/issues/4/comments").thenReply(
-        200,
-        JSON.stringify(
-          fixtures.github.getIssueCommentPayload({
-            org: "paritytech-stg",
-            repo: "testre",
-            comment: {
-              author: "substrate-tip-bot",
-              body: "",
-              id: 4,
-            },
-          }),
-        ),
-      );
+      const successEndpoint = await gitHub
+        .forPost("/repos/paritytech-stg/testre/issues/4/comments")
+        .withHeaders({ Authorization: `token ${paritytechStgOrgToken}` })
+        .thenReply(
+          200,
+          JSON.stringify(
+            fixtures.github.getIssueCommentPayload({
+              org: "paritytech-stg",
+              repo: "testre",
+              comment: {
+                author: "substrate-tip-bot",
+                body: "",
+                id: 4,
+              },
+            }),
+          ),
+        );
+
+      await tipUser(appPort, tipSize);
 
       await until(async () => !(await successEndpoint.isPending()), 500, 100);
 
@@ -290,20 +327,23 @@ describe("tip", () => {
 
     test(`huge tip in ${network}`, async () => {
       await expectTipperMembership();
-      const successEndpoint = await gitHub.forPost("/repos/paritytech-stg/testre/issues/4/comments").thenReply(
-        200,
-        JSON.stringify(
-          fixtures.github.getIssueCommentPayload({
-            org: "paritytech-stg",
-            repo: "testre",
-            comment: {
-              author: "substrate-tip-bot",
-              body: "",
-              id: 4,
-            },
-          }),
-        ),
-      );
+      const successEndpoint = await gitHub
+        .forPost("/repos/paritytech-stg/testre/issues/4/comments")
+        .withHeaders({ Authorization: `token ${paritytechStgOrgToken}` })
+        .thenReply(
+          200,
+          JSON.stringify(
+            fixtures.github.getIssueCommentPayload({
+              org: "paritytech-stg",
+              repo: "testre",
+              comment: {
+                author: "substrate-tip-bot",
+                body: "",
+                id: 4,
+              },
+            }),
+          ),
+        );
 
       await tipUser(appPort, "1000000");
 
@@ -318,20 +358,23 @@ describe("tip", () => {
 
     test(`tip link in ${network}`, async () => {
       await expectNoTipperMembership();
-      const successEndpoint = await gitHub.forPost("/repos/paritytech-stg/testre/issues/4/comments").thenReply(
-        200,
-        JSON.stringify(
-          fixtures.github.getIssueCommentPayload({
-            org: "paritytech-stg",
-            repo: "testre",
-            comment: {
-              author: "substrate-tip-bot",
-              body: "",
-              id: 4,
-            },
-          }),
-        ),
-      );
+      const successEndpoint = await gitHub
+        .forPost("/repos/paritytech-stg/testre/issues/4/comments")
+        .withHeaders({ Authorization: `token ${paritytechStgOrgToken}` })
+        .thenReply(
+          200,
+          JSON.stringify(
+            fixtures.github.getIssueCommentPayload({
+              org: "paritytech-stg",
+              repo: "testre",
+              comment: {
+                author: "substrate-tip-bot",
+                body: "",
+                id: 4,
+              },
+            }),
+          ),
+        );
 
       await tipUser(appPort, "small");
 
@@ -342,7 +385,7 @@ describe("tip", () => {
       expect(body.body).toContain(
         "Only members of `tip-bot-org/tip-bot-approvers` have permission to request the creation of the tip referendum from the bot.",
       );
-      expect(body.body).toContain(`https://polkadot.js.org/apps/?rpc=ws://localrococo:9945#/`);
+      expect(body.body).toContain(`https://polkadot.js.org/apps/?rpc=ws://local${network}:9945#/`);
 
       const extrinsicHex = body.body.match(/decode\/(\w+)/)?.[1];
       expect(extrinsicHex).toBeDefined();

--- a/yarn.lock
+++ b/yarn.lock
@@ -793,15 +793,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eng-automation/testing@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "@eng-automation/testing@npm:1.5.0"
+"@eng-automation/testing@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "@eng-automation/testing@npm:1.5.2"
   dependencies:
     "@eng-automation/js": "npm:^2.1.0"
     "@octokit/rest": "npm:^19.0.7"
     mockttp: "npm:^3.9.4"
     selfsigned: "npm:^2.1.0"
-  checksum: 10c0/bab1ac26228d51b8c8450ce1df8a1a2781044057faf95ce81c0edbdba640ee2200a1e2c58ce0b87efb6ed97fde702d2c5e764acf41bda62c72cf4c552ec04248
+  checksum: 10c0/451c699d60b842cab5d797ec95ce186e62cf76cc369f866b04e12591809f0ab00b75b0d51dbc959bc780673c10d40eda094cc75743d3f8161843266af0cfc215
   languageName: node
   linkType: hard
 
@@ -3192,7 +3192,7 @@ __metadata:
     "@eng-automation/integrations": "npm:^4.4.0"
     "@eng-automation/js": "npm:^2.2.0"
     "@eng-automation/js-style": "npm:^3.1.0"
-    "@eng-automation/testing": "npm:^1.5.0"
+    "@eng-automation/testing": "npm:^1.5.2"
     "@polkadot-api/descriptors": "portal:.papi/descriptors"
     "@polkadot-labs/hdkd": "npm:^0.0.6"
     "@polkadot-labs/hdkd-helpers": "npm:^0.0.6"


### PR DESCRIPTION
tip-bot can be installed as an app to a multitude of orgs, but one
app means one server and one approvers org/team.
Querying approvers should be done via installation token of approvers
org, while leaving comments should be done by installation token of
repository, where the PR that's being tipped was opened.

Fixes #169 
