### PR TITLE
Using an org link for "only members of..." comment

### DIFF
--- a/src/bot-handle-comment.ts
+++ b/src/bot-handle-comment.ts
@@ -203,7 +203,7 @@ export const handleTipRequest = async (
     }
 
     let message =
-      `Only members of \`${allowedGitHubOrg}/${allowedGitHubTeam}\` ` +
+      `Only members of [${allowedGitHubOrg}/${allowedGitHubTeam}](https://github.com/orgs/${allowedGitHubOrg}/teams/${allowedGitHubTeam}) ` +
       `have permission to request the creation of the tip referendum from the bot.\n\n`;
     message += `However, you can create the tip referendum yourself using [Polkassembly](https://wiki.polkadot.network/docs/learn-polkadot-opengov-treasury#submit-treasury-proposal-via-polkassembly)`;
     return {

--- a/src/tip.integration.ts
+++ b/src/tip.integration.ts
@@ -383,7 +383,7 @@ describe("tip", () => {
       const [request] = await successEndpoint.getSeenRequests();
       const body = (await request.body.getJson()) as { body: string };
       expect(body.body).toContain(
-        "Only members of `tip-bot-org/tip-bot-approvers` have permission to request the creation of the tip referendum from the bot.",
+        "Only members of [tip-bot-org/tip-bot-approvers](https://github.com/orgs/tip-bot-org/teams/tip-bot-approvers) have permission to request the creation of the tip referendum from the bot.",
       );
       expect(body.body).toContain(`https://polkadot.js.org/apps/?rpc=ws://local${network}:9945#/`);
 


### PR DESCRIPTION
Not everyone recognizes that paritytech/tip-bot-approvers is actually a
team, not a repo. Using a link might clarify it.

Fixes #167
